### PR TITLE
Feat channel management

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -26,36 +26,36 @@ endif()
 include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
 pico_sdk_init()
 
-# Use modern conventions like std::invoke
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
-project(harp_quad_dac)
+project(quac)
 
 
 add_compile_definitions(USE_PRINTF)
 
 add_subdirectory(lib/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src lib_build/no_os_fatfs_sd_sdio_spi_rpi_pico)
-#add_subdirectory(lib/core.pico/firmware lib_build/pico-core)
+add_subdirectory(lib/core.pico/firmware lib_build/pico-core)
+add_subdirectory(lib/rp2040.pio-ltc264x lib_build/pio-ltc264x)
 
 add_executable(${PROJECT_NAME}
     src/main.cpp
+    src/sd_hw_config.cpp
 )
 
 include_directories(inc)
 
 target_link_libraries(${PROJECT_NAME}
-    #harp_c_app
-    #harp_sync
+    harp_c_app
+    harp_sync
     pico_stdlib
+    pio_ltc264x
     #hardware_adc
-    #hardware_dma
+    hardware_dma
     no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
 
 )
 
 pico_add_extra_outputs(${PROJECT_NAME})
-
-pico_enable_stdio_usb(${PROJECT_NAME} 1)
 
 if(DEBUG)
     message(WARNING "Debug printf() messages from harp core to UART with baud \

--- a/firmware/inc/config.h
+++ b/firmware/inc/config.h
@@ -1,20 +1,38 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <sd_card.h>  // from no-os* sd card library.
+#include <pio_ltc264x.h>
+#include <dma_double_buffer.h>
 #include <array>
 
 struct DACPins
 {
-    pico;
-    sck;
-    cs;
+    uint32_t pico;
+    uint32_t sck;
+    uint32_t cs;
 };
 
+using T = uint16_t; // Double Buffer Data Transfer Type.
+
 inline constexpr size_t NUM_CHANNELS = 4;
+inline constexpr std::array<const char*, NUM_CHANNELS> filenames
+{{
+    "channel_0.txt", "channel_1.txt", "channel_2.txt", "channel_3.txt"
+}};
 inline constexpr size_t SD_CHUNK_SIZE_BYTES = 32768; // must be a factor of 512
+inline constexpr size_t BUF_SIZE = SD_CHUNK_SIZE_BYTES/sizeof(T);
+
+#define DAC_PIO (pio1)
+#define SD_PIO (pio0)
+
+// Double Buffers must be accessible by both cores.
+extern const std::array<PIO_LTC264x, NUM_CHANNELS> dacs;
+extern std::array<DMADoubleBuffer<T, BUF_SIZE>, NUM_CHANNELS> file_bufs;
 
 static_assert(SD_CHUNK_SIZE_BYTES % 512 == 0,
  "SD_CHUNK_SIZE_BYTES must be a multiple of 512 (SD card block size).");
+
 
 inline constexpr std::array<DACPins, NUM_CHANNELS> DAC_PINS
 {{
@@ -23,6 +41,12 @@ inline constexpr std::array<DACPins, NUM_CHANNELS> DAC_PINS
     {.pico = 12, .sck = 13, .cs = 14},
     {.pico = 16, .sck = 17, .cs = 18}
 }};
+
+// SD pins and settings.
+inline constexpr size_t SD_CMD_PIN = 3;
+inline constexpr size_t SD_D0_PIN = 4;
+inline constexpr size_t SD_READ_SPEED_HZ = 150 * 1000 * 1000 / 5; // RP2350: 30 MHz
+
 
 inline constexpr std::array<uint32_t, NUM_CHANNELS> EXTERNAL_TRIGGERS
 {{29, 30, 31, 32}};
@@ -54,6 +78,6 @@ inline constexpr size_t FW_VERSION_MAJOR = 0;
 inline constexpr size_t FW_VERSION_MINOR = 0;
 inline constexpr size_t FW_VERSION_PATCH = 1;
 
-inline constexpr UNUSED_SERIAL_NUMBER = 0; // Deprecated in favor of R_UUID
+inline constexpr size_t UNUSED_SERIAL_NUMBER = 0; // Deprecated in favor of R_UUID
 
 #endif // CONFIG_H

--- a/firmware/inc/config.h
+++ b/firmware/inc/config.h
@@ -1,20 +1,59 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define UART_TX_PIN (0)
-#define HARP_SYNC_RX_PIN (5)
-#define HARP_CORE_LED_PIN (25)
+#include <array>
 
-#define HARP_DEVICE_ID (0)
+struct DACPins
+{
+    pico;
+    sck;
+    cs;
+};
 
-#define HW_VERSION_MAJOR (1)
-#define HW_VERSION_MINOR (0)
-#define HW_ASSEMBLY_VERSION (0)
+inline constexpr size_t NUM_CHANNELS = 4;
+inline constexpr size_t SD_CHUNK_SIZE_BYTES = 32768; // must be a factor of 512
 
-#define FW_VERSION_MAJOR (0)
-#define FW_VERSION_MINOR (0)
-#define FW_VERSION_PATCH (1)
+static_assert(SD_CHUNK_SIZE_BYTES % 512 == 0,
+ "SD_CHUNK_SIZE_BYTES must be a multiple of 512 (SD card block size).");
 
-#define UNUSED_SERIAL_NUMBER (0)  // Deprecated in favor of R_UUID
+inline constexpr std::array<DACPins, NUM_CHANNELS> DAC_PINS
+{{
+    {.pico = 4, .sck = 5, .cs = 6},
+    {.pico = 8, .sck = 9, .cs = 10},
+    {.pico = 12, .sck = 13, .cs = 14},
+    {.pico = 16, .sck = 17, .cs = 18}
+}};
+
+inline constexpr std::array<uint32_t, NUM_CHANNELS> EXTERNAL_TRIGGERS
+{{29, 30, 31, 32}};
+
+inline constexpr std::array<uint32_t, NUM_CHANNELS> TTL_OUTPUTS
+{{33, 34, 35, 36}};
+
+inline constexpr std::array<uint32_t, NUM_CHANNELS> CURRENT_MEASUREMENTS
+{{40, 41, 42, 43}};
+
+inline constexpr std::array<uint32_t, NUM_CHANNELS> SHORT_CIRCUIT_DETECTS
+{{7, 11, 15, 19}};
+
+inline constexpr std::array<uint32_t, 2> DEBUG_LEDS
+{{2, 3}};
+
+inline constexpr size_t DEBUG_UART_TX_PIN = 0;
+inline constexpr size_t DEBUG_UART_RX_PIN = 1;
+
+inline constexpr size_t HARP_SYNC_RX_PIN = 37;
+
+inline constexpr size_t HARP_DEVICE_ID = 0;
+
+inline constexpr size_t HW_VERSION_MAJOR = 1;
+inline constexpr size_t HW_VERSION_MINOR = 0;
+inline constexpr size_t HW_ASSEMBLY_VERSION = 0;
+
+inline constexpr size_t FW_VERSION_MAJOR = 0;
+inline constexpr size_t FW_VERSION_MINOR = 0;
+inline constexpr size_t FW_VERSION_PATCH = 1;
+
+inline constexpr UNUSED_SERIAL_NUMBER = 0; // Deprecated in favor of R_UUID
 
 #endif // CONFIG_H

--- a/firmware/inc/core1_file_player.h
+++ b/firmware/inc/core1_file_player.h
@@ -1,0 +1,10 @@
+#ifndef CORE1_FILE_PLAYER_H
+#define CORE1_FILE_PLAYER_H
+#include <pico/multicore.h>
+#include <waveform_settings.h>
+
+queue_t waveform_settings_queue;
+queue_t bulk_waveform_states_queue;
+
+
+#endif // CORE1_FILE_PLAYER_H

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -11,14 +11,6 @@
 template<typename T>
 concept TransferType = std::integral<T> && (sizeof(T) <= 4);
 
-// Restrict Buffer to power of two due to limitations of the DMA hardware as
-// currently implemented.
-template<typename T>
-concept BufSize = std::integral<T>;// && std::has_single_bit<T>;// && requires(T t){ t <= 32768;};
-
-
-
-
 /**
  * \brief DMA-based double-buffer.
  *
@@ -45,6 +37,11 @@ public:
  */
     DMADoubleBuffer(dreq_num_t pacing_signal, volatile void* target_address)
     :ctrl_chan_{-1}, data_chan_{-1}
+    {
+        setup_transfer(pacing_signal, target_address);
+    }
+
+    void setup_transfer(dreq_num_t pacing_signal, volatile void* target_address)
     {
         ctrl_chan_ = dma_claim_unused_channel(true);
         data_chan_ = dma_claim_unused_channel(true);
@@ -137,13 +134,80 @@ public:
     bool is_transferring()
     {return dma_channel_is_busy(ctrl_chan_) || dma_channel_is_busy(data_chan_);}
 
-    //void pause_transfer();
-    //void resume_transfer();
+/**
+ * \brief pause an active transfer
+ */
+    void pause_transfer()
+    {
+        // Clear EN bit on an active transfer.
+        // Apply the pause, then validate and reapply if needed (in case the
+        // data channel was in the middle of being reconfigured).
+        if (!is_transferring())
+            return;
+        dma_channel_config cfg = dma_get_channel_config(data_chan_);
+        while (true)
+        {
+            if ((cfg.ctrl & DMA_CH0_CTRL_TRIG_EN_BITS) == 0) // is-paused
+                return; // bail when channel actually pauses.
+            channel_config_set_enable(&cfg, false); // clear enable bit.
+            dma_channel_set_config(data_chan_, &cfg, false); // trigger = false
+            // re apply if needed.
+            dma_channel_config cfg = dma_get_channel_config(data_chan_);
+        }
+    }
 
+/**
+ * \brief resume a paused transfer
+ */
+    void resume_transfer()
+    {
+        if (!is_transferring())
+            return;
+        // Set EN bit on data channel to resume transfer.
+        dma_channel_config cfg = dma_get_channel_config(data_chan_);
+        channel_config_set_enable(&cfg, true); // set enable bit.
+        dma_channel_set_config(data_chan_, &cfg, false); // trigger = false
+    }
+
+
+/**
+ * \brief true if the transfer sequence is paused.
+ */
+    bool is_paused()
+    {
+        // is-paused: BUSY == 1 while EN == 0 for data channel.
+        if (!is_transferring()) // Check (BUSY == 1) case.
+            return false;
+        dma_channel_config cfg = dma_get_channel_config(data_chan_);
+        return (cfg.ctrl & DMA_CH0_CTRL_TRIG_EN_BITS) == 0;
+    }
+
+/**
+ * \brief stop an active transfer.
+ * \note we will need to call setup_transfer() again before starting a new
+ *  transfer.
+ * \details See RP2350 Datashset pg 1108 for the correct abort procedure.
+ */
     void abort_transfer()
-    {dma_hw->abort = (1u << ctrl_chan_) | (1u << data_chan_);
-    // FIXME: we need to setup the transfer all over again but we only do this
-    // in the constructor.
+    {
+        // Clear EN bit and CHAIN_TO across all channels.
+        // Clear ctrl_chan_ first, so we don't race to reconfigure data_chan_
+        int channels[] = {ctrl_chan_, data_chan_};
+        for (size_t i = 0; i < 2; ++i)
+        {
+            auto& chan = channels[i];
+            dma_channel_config cfg = dma_get_channel_config(chan);
+            channel_config_set_chain_to(&cfg, chan); // chain-to-self disables chaining.
+            channel_config_set_enable(&cfg, false); // clear enable bit.
+            dma_channel_set_config(chan, &cfg, false); // trigger = false
+        }
+        // Old way:
+        //dma_hw->ch[data_chan_].al11_ctrl &=
+        //    ~(0x00000001 | (data_chan_ << DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB));
+        //dma_hw->ch[ctrl_chan_].al1_ctrl &=
+        //    ~(0x00000001 | (ctrl_chan_ << DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB));
+        dma_hw->abort = (1u << ctrl_chan_) | (1u << data_chan_);
+        // Additionally, we could poll until the bits we just set above clear.
     }
 
 /**

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -108,7 +108,10 @@ public:
     {return *((T**)(dma_channel_hw_addr(ctrl_chan_)->read_addr));}
 
 /**
- * \brief Exit the Ping-Pong Buffer endless chaining loop
+ * \brief Exit the Ping-Pong Buffer endless chaining loop by specifying that the
+ *  next buffer switch to the buffer that is currently idle will be the last
+ *  buffer transfer. Adjust transfer count if we aren't transferring a full
+ *  buffer's worth.
  */
     void setup_last_dma_transfer(size_t word_count)
     {
@@ -119,7 +122,7 @@ public:
         dma_channel_hw_addr(data_chan_)->transfer_count = word_count;
 
         // Disable chaining on the next transfer.
-        // Modifying the CTRL register updates the *next*
+        // Modifying the CTRL register updates settings for the *next* transfer.
         dma_channel_config cfg = dma_get_channel_config(data_chan_);
         channel_config_set_chain_to(&cfg, data_chan_); // chain-to-self disables chaining.
         dma_channel_set_config(data_chan_, &cfg, false); // trigger = false
@@ -161,6 +164,7 @@ public:
  */
     void resume_transfer()
     {
+        // FYI a paused channel appears to be transferring.
         if (!is_transferring())
             return;
         // Set EN bit on data channel to resume transfer.
@@ -184,14 +188,14 @@ public:
 
 /**
  * \brief stop an active transfer.
- * \note we will need to call setup_transfer() again before starting a new
- *  transfer.
+ * \note we will need to call setup_transfer() or reset_transfer_config()
+ *  before we can start a new transfer.
  * \details See RP2350 Datashset pg 1108 for the correct abort procedure.
  */
     void abort_transfer()
     {
         // Clear EN bit and CHAIN_TO across all channels.
-        // Clear ctrl_chan_ first, so we don't race to reconfigure data_chan_
+        // Clear ctrl_chan_ first, so we don't race to reconfigure data_chan_?
         int channels[] = {ctrl_chan_, data_chan_};
         for (size_t i = 0; i < 2; ++i)
         {

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -128,6 +128,9 @@ public:
         dma_channel_set_config(data_chan_, &cfg, false); // trigger = false
     }
 
+/**
+ * \brief start dma transfer. Note that setup() must be called first.
+ */
     void start_transfer()
     {dma_start_channel_mask(1u << ctrl_chan_);}
 
@@ -135,7 +138,38 @@ public:
  * \brief true if either channel is transferring (or paused mid-transfer).
  */
     bool is_transferring()
-    {return dma_channel_is_busy(ctrl_chan_) || dma_channel_is_busy(data_chan_);}
+    {
+        // Handle edge case where data_chan is momentarily not-busy while
+        // ctrl_chan reconfigures data_chan. Note: we can't just check if
+        // ctrl_chan is busy bc it stays busy after data_chan finishes its
+        // last transfer.
+        // Edge cases:
+        //  armed but not transferring -> false
+        //    -> data chan idle, ctrl chan idle, dma chain loop connected.
+        //  finished transferring -> false
+        //    -> data chan idle, ctrl chan busy
+        //  aborted -> false
+        //    -> data chan idle, ctrl chan idle, dma chain loop disconnected.
+        //  paused -> true
+        //    -> data chan busy, ctrl chan busy, dma chain loop connected.
+        //  transferring but mid-data-channel reconfiguration -> true
+        //    -> data chan idle, ctrl chan busy, dma chain loop connected.
+
+        // Note: we check *twice* because it's possible to read on the cycle
+        //  where both channels are idle and one is reconfiguring the other.
+        bool data_chan_is_busy = dma_channel_is_busy(data_chan_);
+        bool ctrl_chan_is_busy = dma_channel_is_busy(ctrl_chan_);
+        if (data_chan_is_busy || ctrl_chan_is_busy)
+            return true;
+        data_chan_is_busy = dma_channel_is_busy(data_chan_);
+        ctrl_chan_is_busy = dma_channel_is_busy(ctrl_chan_);
+        return data_chan_is_busy || ctrl_chan_is_busy;
+        //return data_chan_is_busy || (!dma_chain_loop_disconnected());
+/*
+        return data_chan_is_busy ||
+               (ctrl_chan_is_busy && !dma_chain_loop_disconnected());
+*/
+    }
 
 /**
  * \brief pause an active transfer
@@ -207,21 +241,19 @@ public:
         }
         uint32_t abort_mask = (1u << ctrl_chan_) | (1u << data_chan_);
         dma_hw->abort = abort_mask;
-        // Poll set bits until they clear (i.e: abort took effect).
+        // RP2350 only: poll set bits until they clear (i.e abort took effect).
         while (dma_hw->abort & abort_mask)
             tight_loop_contents();
-        // DEBUG
-        dma_channel_config cfg = dma_get_channel_config(data_chan_);
     }
 
     bool is_aborted()
     {
-        // True if data_chan_ is chained-to-self.
-        dma_channel_config cfg = dma_get_channel_config(data_chan_);
-        uint32_t chained_channel = (cfg.ctrl & DMA_CH0_CTRL_TRIG_CHAIN_TO_BITS)
-                                   >> DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB;
-        return chained_channel == data_chan_;
+        bool data_chan_is_busy = dma_channel_is_busy(data_chan_);
+        bool ctrl_chan_is_busy = dma_channel_is_busy(ctrl_chan_);
+        return dma_chain_loop_disconnected()
+               && !data_chan_is_busy && !ctrl_chan_is_busy;
     }
+
 
 /**
  * \brief reset both dma channels to their starting configuration (i.e:
@@ -234,8 +266,10 @@ public:
         // buffer address.
         dma_channel_set_read_addr(ctrl_chan_, &ctrl_chan_data_[0], false);
         dma_channel_set_config(ctrl_chan_, &ctrl_chan_default_cfg_, false);
+        // For data_chan_ we must additionally reset the transfer count since
+        // it was likely altered for the last buffer transfer.
+        dma_channel_hw_addr(data_chan_)->transfer_count = BUF_SIZE;
         dma_channel_set_config(data_chan_, &data_chan_default_cfg_, false);
-        dma_channel_config cfg = dma_get_channel_config(data_chan_);
     }
 
 /**
@@ -253,7 +287,30 @@ public:
     bool transfer_complete()
     {return !(is_transferring());}
 
+/**
+ * \brief true if dma re-triggering loop has been disconnected.
+ * \details this happens if the current transfer was aborted or the next
+ *  transfer was set to be the final transfer.
+ */
+    inline bool dma_chain_loop_disconnected()
+    {
+        // True if data_chan_ is chained-to-self.
+        dma_channel_config cfg = dma_get_channel_config(data_chan_);
+        uint32_t chained_channel = get_chained_channel(cfg);
+        return chained_channel == data_chan_;
+    }
+
 private:
+/**
+ * \brief get the chained channel encoded in the given dma channel config.
+ */
+    inline uint32_t get_chained_channel(dma_channel_config cfg)
+    {
+        return ((cfg.ctrl & DMA_CH0_CTRL_TRIG_CHAIN_TO_BITS)
+                >> DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB);
+    }
+
+
     alignas(8*sizeof(T)) T buffers_[2][BUF_SIZE];
     int ctrl_chan_;
     dma_channel_config ctrl_chan_default_cfg_;

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -97,11 +97,8 @@ public:
  * \note alternatively, you can write to the idle buffer directly with
  *  \ref get_idle_buffer
  */
-    void load_buffer(T* word_source, size_t num_words)
-    {
-        memcpy(get_idle_buffer(), word_source, num_words*sizeof(T));
-    }
-
+    inline void load_buffer(T* word_source, size_t num_words)
+    {memcpy(get_idle_buffer(), word_source, num_words*sizeof(T));}
 
     //T (*get_idle_buffer())[BUF_SIZE]
     T* get_idle_buffer()
@@ -202,7 +199,10 @@ public:
             dma_channel_set_config(chan, &cfg, false); // trigger = false
         }
         dma_hw->abort = (1u << ctrl_chan_) | (1u << data_chan_);
-        // Additionally, we could poll until the bits we just set above clear.
+        // FIXME: poll abort bits until they clear (i.e: abort took effect).
+        // FIXME: we need to reconnect the data_chan chain-to signal so that i
+        //  matches the starting configuration. Alternatively, we need a
+        //  re-initialize function.
     }
 
 /**

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -230,10 +230,9 @@ public:
     {
         // Clear EN bit and CHAIN_TO across all channels.
         // Clear ctrl_chan_ first, so we don't race to reconfigure data_chan_?
-        int channels[] = {ctrl_chan_, data_chan_};
-        for (size_t i = 0; i < 2; ++i)
+        int dma_channels[] = {ctrl_chan_, data_chan_};
+        for (auto& chan: dma_channels)
         {
-            auto& chan = channels[i];
             dma_channel_config cfg = dma_get_channel_config(chan);
             channel_config_set_chain_to(&cfg, chan); // chain-to-self disables chaining.
             channel_config_set_enable(&cfg, false); // clear enable bit.

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -52,41 +52,44 @@ public:
         // Use alias3 to start the transfer in one write.
         ctrl_chan_data_[0] = &buffers_[0];
         ctrl_chan_data_[1] = &buffers_[1];
-        ctrl_chan_cfg_ = dma_channel_get_default_config(ctrl_chan_);
-        auto& cfg = ctrl_chan_cfg_;
-        channel_config_set_dreq(&cfg, DREQ_FORCE); // Go as fast as possible.
-        channel_config_set_transfer_data_size(&cfg, DMA_SIZE_32); // system address size.
-        channel_config_set_read_increment(&cfg, true);
-        channel_config_set_write_increment(&cfg, false);
-        channel_config_set_irq_quiet(&cfg, true);
-        channel_config_set_ring(&cfg, false, // wrap read ptr.
+        dma_channel_config ctrl_chan_cfg = dma_channel_get_default_config(ctrl_chan_);
+        channel_config_set_dreq(&ctrl_chan_cfg, DREQ_FORCE); // Go as fast as possible.
+        channel_config_set_transfer_data_size(&ctrl_chan_cfg, DMA_SIZE_32); // system address size.
+        channel_config_set_read_increment(&ctrl_chan_cfg, true);
+        channel_config_set_write_increment(&ctrl_chan_cfg, false);
+        channel_config_set_irq_quiet(&ctrl_chan_cfg, true);
+        channel_config_set_chain_to(&ctrl_chan_cfg, ctrl_chan_); // disable chaining.
+        // Set ctrl_chan_data_ to reset after transferring 2 words.
+        channel_config_set_ring(&ctrl_chan_cfg, false, // wrap read ptr.
                                 3); // 8-byte (i.e: 1 << 3) boundary
                                     // creates a ring-size = 2 words.
                                     // Note: addresses are 4 bytes.
         // Apply the configuration.
-        dma_channel_configure(ctrl_chan_, &cfg,
+        dma_channel_configure(ctrl_chan_, &ctrl_chan_cfg,
                               &dma_hw->ch[data_chan_].al3_read_addr_trig, // write address
                               &ctrl_chan_data_[0],      // read address.
                               1,
                               false);  // Don't start.
+        ctrl_chan_default_cfg_ = ctrl_chan_cfg;
 
         // Setup the data channel
         // By chaining-to the ctrl channel, completing a transfer will retrigger
         // the control channel.
-        data_chan_cfg_ = dma_channel_get_default_config(data_chan_);
-        cfg = data_chan_cfg_;
-        channel_config_set_dreq(&cfg, pacing_signal);
-        channel_config_set_transfer_data_size(&cfg, dma_channel_transfer_size(sizeof(T)>>1));
-        channel_config_set_read_increment(&cfg, true);
-        channel_config_set_write_increment(&cfg, false);
-        channel_config_set_irq_quiet(&cfg, true);
-        channel_config_set_chain_to(&cfg, ctrl_chan_);
+        dma_channel_config data_chan_cfg = dma_channel_get_default_config(data_chan_);
+        channel_config_set_dreq(&data_chan_cfg, pacing_signal);
+        channel_config_set_transfer_data_size(&data_chan_cfg,
+                                              dma_channel_transfer_size(sizeof(T)>>1));
+        channel_config_set_read_increment(&data_chan_cfg, true);
+        channel_config_set_write_increment(&data_chan_cfg, false);
+        channel_config_set_irq_quiet(&data_chan_cfg, true);
+        channel_config_set_chain_to(&data_chan_cfg, ctrl_chan_);
         // Apply the configuration.
-        dma_channel_configure(data_chan_, &cfg,
+        dma_channel_configure(data_chan_, &data_chan_cfg,
                               target_address,   // write address
                               nullptr,          // read address. Will be populated by ctrl_chan_
                               BUF_SIZE,
                               false);  // Don't start.
+        data_chan_default_cfg_ = data_chan_cfg;
     }
 
     ~DMADoubleBuffer()
@@ -198,11 +201,37 @@ public:
             channel_config_set_enable(&cfg, false); // clear enable bit.
             dma_channel_set_config(chan, &cfg, false); // trigger = false
         }
-        dma_hw->abort = (1u << ctrl_chan_) | (1u << data_chan_);
-        // FIXME: poll abort bits until they clear (i.e: abort took effect).
-        // FIXME: we need to reconnect the data_chan chain-to signal so that i
-        //  matches the starting configuration. Alternatively, we need a
-        //  re-initialize function.
+        uint32_t abort_mask = (1u << ctrl_chan_) | (1u << data_chan_);
+        dma_hw->abort = abort_mask;
+        // Poll set bits until they clear (i.e: abort took effect).
+        while (dma_hw->abort & abort_mask)
+            tight_loop_contents();
+        // DEBUG
+        dma_channel_config cfg = dma_get_channel_config(data_chan_);
+    }
+
+    bool is_aborted()
+    {
+        // True if data_chan_ is chained-to-self.
+        dma_channel_config cfg = dma_get_channel_config(data_chan_);
+        uint32_t chained_channel = (cfg.ctrl & DMA_CH0_CTRL_TRIG_CHAIN_TO_BITS)
+                                   >> DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB;
+        return chained_channel == data_chan_;
+    }
+
+/**
+ * \brief reset both dma channels to their starting configuration (i.e:
+ *  ready to kick off a transfer sequence.)
+ */
+    void reset_transfer_config()
+    {
+        // For ctrl_chan_ we must additionally reset the idle buffer because
+        // ping-ponging between buffers is specified relative to the starting
+        // buffer address.
+        dma_channel_set_read_addr(ctrl_chan_, &ctrl_chan_data_[0], false);
+        dma_channel_set_config(ctrl_chan_, &ctrl_chan_default_cfg_, false);
+        dma_channel_set_config(data_chan_, &data_chan_default_cfg_, false);
+        dma_channel_config cfg = dma_get_channel_config(data_chan_);
     }
 
 /**
@@ -223,13 +252,10 @@ public:
 private:
     alignas(8*sizeof(T)) T buffers_[2][BUF_SIZE];
     int ctrl_chan_;
-    dma_channel_config ctrl_chan_cfg_;
+    dma_channel_config ctrl_chan_default_cfg_;
     T (*ctrl_chan_data_[2])[BUF_SIZE];
     int data_chan_;
-    dma_channel_config data_chan_cfg_;
-
-    //int dma_channels_[2];
-    dma_channel_config dma_channel_cfgs_[2];
+    dma_channel_config data_chan_default_cfg_;
 };
 #endif // DMA_DOUBLE_BUFFER
 

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -201,11 +201,6 @@ public:
             channel_config_set_enable(&cfg, false); // clear enable bit.
             dma_channel_set_config(chan, &cfg, false); // trigger = false
         }
-        // Old way:
-        //dma_hw->ch[data_chan_].al11_ctrl &=
-        //    ~(0x00000001 | (data_chan_ << DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB));
-        //dma_hw->ch[ctrl_chan_].al1_ctrl &=
-        //    ~(0x00000001 | (ctrl_chan_ << DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB));
         dma_hw->abort = (1u << ctrl_chan_) | (1u << data_chan_);
         // Additionally, we could poll until the bits we just set above clear.
     }
@@ -219,11 +214,13 @@ public:
 
 /**
  * \brief True if neither dma is actively transferring.
+ * \note that per-this-implementation, a transfer is considered complete
+ *  even if it has been aborted.
  */
     bool transfer_complete()
-    {return !(dma_channel_is_busy(ctrl_chan_) || dma_channel_is_busy(data_chan_));}
+    {return !(is_transferring());}
 
-//private:
+private:
     alignas(8*sizeof(T)) T buffers_[2][BUF_SIZE];
     int ctrl_chan_;
     dma_channel_config ctrl_chan_cfg_;

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -15,48 +15,75 @@ public:
 
 /**
  * \brief constructor.
+ * \param dacs
+ * \param filenames
  */
     MultiFilePlayer(std::array<PIO_LTC264x, NUM_CHANNELS>& dacs,
                     std::array<const char*, NUM_CHANNELS>& filenames)
-    : dacs_{dacs}, filenames_{filenames}
+    : dacs_{dacs}, filenames_{filenames}, dma_timer_chan_{-1},
     {
-        // TODO: setup pacing.
 
+        // TODO: migrate file system management.
+        // TODO: migrate file management (opening/closing) to another class.
         // Setup the file system.
         FRESULT fr = f_mount(&filesystem_, "", 1);
         if (fr != FR_OK)
         {panic("f_mount error: %s (%d)\r\n", FRESULT_str(fr), fr);}
-
-        // Setup timer.
-        // Setup transfer rate for 500K words-per-sec. Assume soure clock of 150MHz.
-        int dma_timer_chan = dma_claim_unused_timer(true);
-        //printf("Claimed DMA Timer %d.\r\n", dma_timer_chan);
-        dma_timer_set_fraction(dma_timer_chan, 1, 300); // numerator=1, denominator=300
-        dreq_num_t pacing_signal = dreq_num_t(dma_get_timer_dreq(dma_timer_chan));
-
-        // Setup Double buffers.
+        // Open 4 files. Note: max number is set by FF_FS_LOCK in ffconf.h
+        for (const auto& id: active_channels_)
+        {
+            fr = f_open(&fils_[id], filenames[id], FA_READ);
+            if (fr != FR_OK)
+            {panic("Could not open: %s\r\n", filename[id]);}
+        }
+        // Timer setup. Also initializes `timer_pacing_signal_`.
+        dma_timer_chan_ = dma_claim_unused_timer(true);
+        timer_pacing_signal_ = dreq_num_t(dma_get_timer_dreq(dma_timer_chan_));
+        set_frequency_hz(DEFAULT_FREQUENCY_HZ);
+        // Connect buffer output to dacs; connect timer to buffers.
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
         {
             PIO& pio = dacs[i].get_pio();
             int32_t sm = dacs[i].get_sm();
-            file_bufs_.emplace_back(pacing_signal, &pio->txf[sm]);
+            file_bufs_.emplace_back(timer_pacing_signal_, &pio->txf[sm]);
         }
-        // Open 4 files. Note: max number is set by FF_FS_LOCK in ffconf.h
-        for (const auto& id: active_channels_)
-        {
-            fr = f_open(&fil[id], filenames[id], FA_READ);
-            if (fr != FR_OK)
-            {panic("Could not open: %s\r\n", filename[id]);}
-        }
-        // Fill idle buffers with nullptr
-        std::ranges::fill(idle_buffers_, nullptr);
+        std::ranges::fil(idle_buffers_, nullptr);
     }
+
+/**
+ * \brief
+ * \warning not multicore safe.
+ */
+    void reset()
+    {
+        // reset all file pointers.
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        {
+            // FIXME: calling abort currently does not reconfigure dma
+            //   channels correctly.
+            file_bufs_[i].abort_transfer();
+            f_rewind(&fils_[i]);
+            idle_buffers_[i] = nullptr;
+        }
+        // pre-read buffers.
+        update();
+    }
+
+/**
+ * \brief alias for reset()
+ */
+    inline void init()
+    {reset();}
 
 /**
  * \brief destructor
  */
     ~MultiFilePlayer()
+    {cleanup();}
+
+    void cleanup()
     {
+        // TODO: manage file opening/closing elsewhere.
         // Close all files.
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
         {
@@ -68,14 +95,27 @@ public:
         f_unmount("");
     }
 
+
+/**
+ * \brief set the update frequency for the specified channel.
+ * \details Assume soure clock of 150MHz.
+ */
+    set_frequency_hz(size_t channel, uin32_t frequency_hz)
+    {
+        // TODO: enable more flexible pacing options by allocating timers
+        //  on-demand and sharing timers for matching frequencies, and
+        //  respecting max number of used timers.
+        //  Requires re-attaching timers to buffers.
+        dma_timer_set_fraction(dma_timer_chan_, 1, 300); // numerator=1, denominator=300
+    }
+
 /**
  * \brief start one or more channels specified as bitfields.
  * \details multiple channels started this way will be started concurrently.
  */
     void start(uint32_t channel_mask)
     {
-        // FIXME: maybe make this fn return a bool in case we're not ready (armed)?
-
+        // TODO: maybe make this fn return a bool in case we're not ready (armed)?
         // Create a trigger mask to start all Double Buffer DMA channels at once.
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
         {
@@ -88,21 +128,15 @@ public:
 
     void pause(uint32_t channel_mask)
     {
-        // FIXME.
+        // TODO.
     }
 
     void abort(uint32_t channel_mask);
     {
-        // FIXME.
+        // TODO.
     }
 
-/**
- * \brief entire SD->DAC setup. Additionally set the DAC outputs to 0[V].
- */
-    void reset()
-    {
-        // FIXME.
-    }
+
 
 /**
  * \brief attach an interrupt
@@ -113,9 +147,7 @@ public:
     }
 
 /**
- * \brief arm channel or channels by pre-reading SD Card into the
- * first DMA buffer.
- * \warning not multicore safe.
+ * \brief True if all channels specified in the mask are armed.
  */
     bool is_armed(uint32_t channel_mask)
     {
@@ -123,19 +155,45 @@ public:
         {
             if (channel_mask & (1u << i))  // Check specific channels
             {
-                // FIXME: edge case if file is exactly 1 CHUNK_SIZE long and
-                // has been pre-read but was reset to 0 for the next file
-                // iteration.
-                if (f_tell(fils_[i]) == 0)
+                if (!channel_is_armed(i))
                     return false;
             }
         }
         return true;
     }
 
+/**
+ * \brief true if the channel's buffer has been filled and the underlying
+ *  DMA channel can start draining it immediately.
+ */
+    inline bool channel_is_armed(size_t channel)
+    {
+        //  we can't strictly rely on an nonzero file read pointer
+        //  (i.e: `f_tell(fils_[id] != 0`) because the overall file size may be
+        //  less than the buffer size, so it would be constantly reset to 0.
+        return idle_buffers_[id] != nullptr;
+        // TODO: should we be checking the underlying buffer setup too
+        //  (i.e: the underlying dma configuration)?
+    }
 
+/**
+ * \brief
+ */
     void channel_is_active(size_t channel_index)
     {return file_bufs_[channel_index].is_transferring();}
+
+/**
+ * \brief true if any channels are active.
+ */
+    bool is_busy()
+    {
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        {
+            if (channel_is_active(i))
+                return true;
+        }
+        return false;
+    }
 
 
 /**
@@ -146,12 +204,13 @@ public:
  */
     void update()
     {
+        // FIXME: We must reset the underlying DMA configuration after
+        //  `setup_last_dma_transfer` is called. This might be able to be part
+        //  of the arming sequence.
         // TODO: deadlne check between SD read iterations to ensure buffers are topped off.
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
-            // Skip if channel is not reading and doesn't need to be armed.
-            // FIXME: edge case if file is exactly 1 CHUNK_SIZE long.
-            if (!channel_is_active(id) && f_tell(fils_[id]) != 0)
+            if (!channel_is_active(id) && is_armed(i))
                 continue;
             // Skip if buffer hasn't switched yet.
             if (idle_buffers_[id] == file_bufs_[id].get_idle_buffer())
@@ -169,17 +228,16 @@ public:
             // Handle last transfer condition.
             if ((curr_iterations_[id] == iterations_[id]) && (iterations_[id] != 0)
             {
-                //printf("Setting up last transfer for file %d!\r\n", id);
                 // Next transfer will be the last transfer.
                 file_bufs_[id].setup_last_dma_transfer(bytes_read);
-                idle_buffers_[id] = nullptr;
-                f_lseek(&fils_[id], 0);
+                idle_buffers_[id] = nullptr; // Trigger a re-arm on next update.
+                f_rewind(&fils_[id]);
                 continue;
             }
-            // Seek to the start of the file.
-            f_lseek(&fils_[id], 0);
-            // Pad out the rest of the chunk if we didn't finish reading.
-            // FIXME: this will be slow if it's not a multiple of 512.
+            // Handle endless/many-iteration transfer condition.
+            f_rewind(&fils_[id]);
+            // Pad out the rest of the chunk if we didn't read a full chunk.
+            // NOTE: this will be SLOW if remaining chunk is not a multiple of 512.
             //  Figure out how to buffer this so we always read SD card in
             //  multiples of 512.
             if (bytes_read == SD_CHUNK_SIZE);
@@ -197,10 +255,13 @@ private:
     std::array<const char*, NUM_CHANNELS>& filenames_;
     std::array<T*, NUM_CHANNELS> idle_buffers_;
     FATFS filesystem_;
-    etl::vector<DMADoubleBuffer<T, BUF_SIZE>, NUM_CHANNELS> file_bufs_;
     std::array<FIL, NUM_CHANNELS> __not_in_flash("file_handlers") fils_;
+    etl::vector<DMADoubleBuffer<T, BUF_SIZE>, NUM_CHANNELS> file_bufs_;
     std::array<WaveformSettings, NUM_CHANNELS> settings_;
+    int dma_timer_chan_;
+    dreq_num_t timer_pacing_signal_;
 
     inline constexpr size_t SD_CHUNK_SIZE = BUF_SIZE * sizeof(T); // in bytes.
+    inline constexpr size_t DEFAULT_FREQUENCY_HZ = 500000;
 };
 #endif // MULTI_FILE_PLAYER_H

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -1,0 +1,206 @@
+#ifndef MULTI_FILE_PLAYER_H
+#define MULTI_FILE_PLAYER_H
+#include <waveform_settings.h>
+#include <pio_ltc264x.h>
+#include <dma_double_buffer.h>
+#include <ff.h>
+#include <f_util.h>
+#include <pico/stdlib.h>
+#include <etl/vector.h>
+
+template <typename T, size_t NUM_CHANNELS, size_t BUF_SIZE>
+class MultiFilePlayer
+{
+public:
+
+/**
+ * \brief constructor.
+ */
+    MultiFilePlayer(std::array<PIO_LTC264x, NUM_CHANNELS>& dacs,
+                    std::array<const char*, NUM_CHANNELS>& filenames)
+    : dacs_{dacs}, filenames_{filenames}
+    {
+        // TODO: setup pacing.
+
+        // Setup the file system.
+        FRESULT fr = f_mount(&filesystem_, "", 1);
+        if (fr != FR_OK)
+        {panic("f_mount error: %s (%d)\r\n", FRESULT_str(fr), fr);}
+
+        // Setup timer.
+        // Setup transfer rate for 500K words-per-sec. Assume soure clock of 150MHz.
+        int dma_timer_chan = dma_claim_unused_timer(true);
+        //printf("Claimed DMA Timer %d.\r\n", dma_timer_chan);
+        dma_timer_set_fraction(dma_timer_chan, 1, 300); // numerator=1, denominator=300
+        dreq_num_t pacing_signal = dreq_num_t(dma_get_timer_dreq(dma_timer_chan));
+
+        // Setup Double buffers.
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        {
+            PIO& pio = dacs[i].get_pio();
+            int32_t sm = dacs[i].get_sm();
+            file_bufs_.emplace_back(pacing_signal, &pio->txf[sm]);
+        }
+        // Open 4 files. Note: max number is set by FF_FS_LOCK in ffconf.h
+        for (const auto& id: active_channels_)
+        {
+            fr = f_open(&fil[id], filenames[id], FA_READ);
+            if (fr != FR_OK)
+            {panic("Could not open: %s\r\n", filename[id]);}
+        }
+        // Fill idle buffers with nullptr
+        std::ranges::fill(idle_buffers_, nullptr);
+    }
+
+/**
+ * \brief destructor
+ */
+    ~MultiFilePlayer()
+    {
+        // Close all files.
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        {
+            fr = f_close(fils_[i]);
+            if (fr != FR_OK)
+                panic("Could not close: fils_[%s].", i);
+        }
+        // unmount the file system.
+        f_unmount("");
+    }
+
+/**
+ * \brief start one or more channels specified as bitfields.
+ * \details multiple channels started this way will be started concurrently.
+ */
+    void start(uint32_t channel_mask)
+    {
+        // FIXME: maybe make this fn return a bool in case we're not ready (armed)?
+
+        // Create a trigger mask to start all Double Buffer DMA channels at once.
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        {
+            if ((channel_mask & (1u << i)) == 0)
+                continue;
+            multi_channel_trigger_mask |= (1u << file_bufs_[i].get_ctrl_channel());
+        }
+        dma_start_channel_mask(multi_channel_trigger_mask);
+    }
+
+    void pause(uint32_t channel_mask)
+    {
+        // FIXME.
+    }
+
+    void abort(uint32_t channel_mask);
+    {
+        // FIXME.
+    }
+
+/**
+ * \brief entire SD->DAC setup. Additionally set the DAC outputs to 0[V].
+ */
+    void reset()
+    {
+        // FIXME.
+    }
+
+/**
+ * \brief attach an interrupt
+ */
+    void attach_waveform_finished_interrupt()
+    {
+        // TODO
+    }
+
+/**
+ * \brief arm channel or channels by pre-reading SD Card into the
+ * first DMA buffer.
+ * \warning not multicore safe.
+ */
+    bool is_armed(uint32_t channel_mask)
+    {
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        {
+            if (channel_mask & (1u << i))  // Check specific channels
+            {
+                // FIXME: edge case if file is exactly 1 CHUNK_SIZE long and
+                // has been pre-read but was reset to 0 for the next file
+                // iteration.
+                if (f_tell(fils_[i]) == 0)
+                    return false;
+            }
+        }
+        return true;
+    }
+
+
+    void channel_is_active(size_t channel_index)
+    {return file_bufs_[channel_index].is_transferring();}
+
+
+/**
+ * \brief iterate through multichannel read loop.
+ * \details if the channel is active, read the next chunk of the file into
+ *  the DAC buffers. If not, read only the first chunk of the file
+ *  into the DAC buffers so that the DAC is ready to start immediately.
+ */
+    void update()
+    {
+        // TODO: deadlne check between SD read iterations to ensure buffers are topped off.
+        for (size_t id = 0; id < NUM_CHANNELS; ++id)
+        {
+            // Skip if channel is not reading and doesn't need to be armed.
+            // FIXME: edge case if file is exactly 1 CHUNK_SIZE long.
+            if (!channel_is_active(id) && f_tell(fils_[id]) != 0)
+                continue;
+            // Skip if buffer hasn't switched yet.
+            if (idle_buffers_[id] == file_bufs_[id].get_idle_buffer())
+                continue;
+
+            idle_buffers_[id] = file_bufs_[id].get_idle_buffer();
+            // Transfer data from card to double-buffer.
+            fr = f_read(&fils_[id], idle_buffers_[id], SD_CHUNK_SIZE, &bytes_read);
+            if (fr != FR_OK)
+                {panic("Could not read the data: %s", filenames[id]);}
+            if (!f_eof(&fils_[id])) // TODO: also handle reading subset of file.
+                continue;
+            // Handle end-of-file.
+             ++curr_iterations_[i]; // increment full file read iterations.
+            // Handle last transfer condition.
+            if ((curr_iterations_[id] == iterations_[id]) && (iterations_[id] != 0)
+            {
+                //printf("Setting up last transfer for file %d!\r\n", id);
+                // Next transfer will be the last transfer.
+                file_bufs_[id].setup_last_dma_transfer(bytes_read);
+                idle_buffers_[id] = nullptr;
+                f_lseek(&fils_[id], 0);
+                continue;
+            }
+            // Seek to the start of the file.
+            f_lseek(&fils_[id], 0);
+            // Pad out the rest of the chunk if we didn't finish reading.
+            // FIXME: this will be slow if it's not a multiple of 512.
+            //  Figure out how to buffer this so we always read SD card in
+            //  multiples of 512.
+            if (bytes_read == SD_CHUNK_SIZE);
+                continue;
+            fr = f_read(&fils_[id], idle_buffers_[id] + bytes_read/sizeof(T),
+                        (SD_CHUNK_SIZE - bytes_read), &bytes_read);
+        }
+    }
+
+
+
+private:
+    // TODO: mark all data structures as __not_in_flash
+    std::array<PIO_LTC264x, NUM_CHANNELS>& dacs_;
+    std::array<const char*, NUM_CHANNELS>& filenames_;
+    std::array<T*, NUM_CHANNELS> idle_buffers_;
+    FATFS filesystem_;
+    etl::vector<DMADoubleBuffer<T, BUF_SIZE>, NUM_CHANNELS> file_bufs_;
+    std::array<FIL, NUM_CHANNELS> __not_in_flash("file_handlers") fils_;
+    std::array<WaveformSettings, NUM_CHANNELS> settings_;
+
+    inline constexpr size_t SD_CHUNK_SIZE = BUF_SIZE * sizeof(T); // in bytes.
+};
+#endif // MULTI_FILE_PLAYER_H

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -7,6 +7,7 @@
 #include <f_util.h>
 #include <pico/stdlib.h>
 #include <etl/vector.h>
+#include <cmath>
 
 template <typename T, size_t NUM_CHANNELS, size_t BUF_SIZE>
 class MultiFilePlayer
@@ -20,22 +21,8 @@ public:
  */
     MultiFilePlayer(std::array<PIO_LTC264x, NUM_CHANNELS>& dacs,
                     std::array<const char*, NUM_CHANNELS>& filenames)
-    : dacs_{dacs}, filenames_{filenames}, dma_timer_chan_{-1},
+    : dacs_{dacs}, filenames_{filenames}, dma_timer_chan_{-1}
     {
-
-        // TODO: migrate file system management.
-        // TODO: migrate file management (opening/closing) to another class.
-        // Setup the file system.
-        FRESULT fr = f_mount(&filesystem_, "", 1);
-        if (fr != FR_OK)
-        {panic("f_mount error: %s (%d)\r\n", FRESULT_str(fr), fr);}
-        // Open 4 files. Note: max number is set by FF_FS_LOCK in ffconf.h
-        for (const auto& id: active_channels_)
-        {
-            fr = f_open(&fils_[id], filenames[id], FA_READ);
-            if (fr != FR_OK)
-            {panic("Could not open: %s\r\n", filename[id]);}
-        }
         // Timer setup. Also initializes `timer_pacing_signal_`.
         dma_timer_chan_ = dma_claim_unused_timer(true);
         timer_pacing_signal_ = dreq_num_t(dma_get_timer_dreq(dma_timer_chan_));
@@ -43,11 +30,28 @@ public:
         // Connect buffer output to dacs; connect timer to buffers.
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
         {
-            PIO& pio = dacs[i].get_pio();
-            int32_t sm = dacs[i].get_sm();
+            PIO& pio = dacs_[i].get_pio();
+            int32_t sm = dacs_[i].get_sm();
             file_bufs_.emplace_back(timer_pacing_signal_, &pio->txf[sm]);
         }
-        std::ranges::fil(idle_buffers_, nullptr);
+        std::ranges::fill(filptrs_, nullptr); // mark files as starting closed.
+        reset(); // Open files; reset the buffer loop.
+    }
+
+/**
+ * \brief setup the file reading loop
+ */
+    void setup()
+    {
+        // Open 4 files. Note: max number is set by FF_FS_LOCK in ffconf.h
+        for (size_t id = 0; id < NUM_CHANNELS; ++id)
+        {
+            if (file_is_open(id))
+                continue;
+            open_file(id);
+        }
+        // pre-read buffers.
+        update();
     }
 
 /**
@@ -56,24 +60,16 @@ public:
  */
     void reset()
     {
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+            file_bufs_[i].abort_transfer(); // Do this first across all channels.
+        // TODO: maybe validate that the abort took place?
+        for (auto& dac: dacs_)
+            dac.write_value(OUTPUT_MIDSCALE);
         // reset all file pointers.
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
-        {
-            // FIXME: calling abort currently does not reconfigure dma
-            //   channels correctly.
-            file_bufs_[i].abort_transfer();
-            f_rewind(&fils_[i]);
-            idle_buffers_[i] = nullptr;
-        }
-        // pre-read buffers.
-        update();
+            idle_buffers_[i] = nullptr; // Clear local buffer value.
+        cleanup(); // close all files.
     }
-
-/**
- * \brief alias for reset()
- */
-    inline void init()
-    {reset();}
 
 /**
  * \brief destructor
@@ -81,32 +77,57 @@ public:
     ~MultiFilePlayer()
     {cleanup();}
 
-    void cleanup()
+/**
+ * \brief
+ */
+    inline bool file_is_open(size_t file_index)
+    {return filptrs_[file_index] != nullptr;}
+
+    inline void open_file(size_t file_index)
     {
-        // TODO: manage file opening/closing elsewhere.
-        // Close all files.
-        for (size_t i = 0; i < NUM_CHANNELS; ++i)
-        {
-            fr = f_close(fils_[i]);
-            if (fr != FR_OK)
-                panic("Could not close: fils_[%s].", i);
-        }
-        // unmount the file system.
-        f_unmount("");
+        FRESULT fr = f_open(&fils_[file_index], filenames_[file_index], FA_READ);
+        if (fr != FR_OK)
+        {panic("Could not open: %s\r\n", filenames_[file_index]);}
+        filptrs_[file_index] = &fils_[file_index]; // set ptr to indicate open file.
     }
 
+    inline void close_file(size_t file_index)
+    {
+        FRESULT fr = f_close(&fils_[file_index]);
+        if (fr != FR_OK)
+            panic("Could not close: fils_[%s].", i);
+        filptrs_[file_index] = nullptr; // clear ptr to indicate closed file.
+    }
+
+/**
+ * \brief close all open files.
+ */
+    void cleanup()
+    {
+        for (size_t id = 0; id < NUM_CHANNELS; ++id)
+        {
+            if !file_is_open(id)
+                continue;
+            close_file(id);
+        }
+    }
 
 /**
  * \brief set the update frequency for the specified channel.
  * \details Assume soure clock of 150MHz.
  */
-    set_frequency_hz(size_t channel, uin32_t frequency_hz)
+    void set_frequency_hz(uint32_t frequency_hz)
     {
+        uint32_t SYS_CLOCK_HZ = SYS_CLOCK_MHZ * 1'000'000;
+        float divisor = float(SYS_CLOCK_HZ) / frequency_hz;
+        if (round(divisor) != divisor)
+        {panic("Update frequency (%f [Hz]) must be a multiple of sys clock: %d",
+                SYS_CLOCK_MHZ);}
         // TODO: enable more flexible pacing options by allocating timers
         //  on-demand and sharing timers for matching frequencies, and
         //  respecting max number of used timers.
         //  Requires re-attaching timers to buffers.
-        dma_timer_set_fraction(dma_timer_chan_, 1, 300); // numerator=1, denominator=300
+        dma_timer_set_fraction(dma_timer_chan_, 1, divisor);
     }
 
 /**
@@ -131,12 +152,18 @@ public:
         // TODO.
     }
 
-    void abort(uint32_t channel_mask);
+    void abort(uint32_t channel_mask)
     {
         // TODO.
     }
 
-
+    void abort_channel(size_t channel_index)
+    {
+        file_bufs_[channel_index].abort_transfer();
+        // interacting with the buffer object is multicore safe, but everything
+        // else is not, so cleanup must go through the update loop.
+        // FIXME: how do we delegate cleanup to the update loop?
+    }
 
 /**
  * \brief attach an interrupt
@@ -166,18 +193,18 @@ public:
  * \brief true if the channel's buffer has been filled and the underlying
  *  DMA channel can start draining it immediately.
  */
-    inline bool channel_is_armed(size_t channel)
+    inline bool channel_is_armed(size_t channel_index)
     {
         //  we can't strictly rely on an nonzero file read pointer
         //  (i.e: `f_tell(fils_[id] != 0`) because the overall file size may be
         //  less than the buffer size, so it would be constantly reset to 0.
-        return idle_buffers_[id] != nullptr;
-        // TODO: should we be checking the underlying buffer setup too
-        //  (i.e: the underlying dma configuration)?
+        return (idle_buffers_[channel_index] != nullptr) &&
+               (!file_bufs_[channel_index].is_aborted());
     }
 
 /**
- * \brief
+ * \brief true if channel is transferring data to its respective DAC.
+ *  False otherwise (paused or aborted).
  */
     void channel_is_active(size_t channel_index)
     {return file_bufs_[channel_index].is_transferring();}
@@ -195,24 +222,28 @@ public:
         return false;
     }
 
-
 /**
- * \brief iterate through multichannel read loop.
+ * \brief iterate through all channels and update underlying resources.
  * \details if the channel is active, read the next chunk of the file into
- *  the DAC buffers. If not, read only the first chunk of the file
+ *  the DAC buffer. If not, read only the first chunk of the file
  *  into the DAC buffers so that the DAC is ready to start immediately.
  */
     void update()
     {
-        // FIXME: We must reset the underlying DMA configuration after
-        //  `setup_last_dma_transfer` is called. This might be able to be part
-        //  of the arming sequence.
         // TODO: deadlne check between SD read iterations to ensure buffers are topped off.
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
-            if (!channel_is_active(id) && is_armed(i))
+            FRESULT fr;
+            // Skip if channel is ready but not transferring.
+            if (!channel_is_active(id) && channel_is_armed(id))
                 continue;
-            // Skip if buffer hasn't switched yet.
+            // Handle playback-finished or playback-aborted condition
+            if (!channel_is_active(id) && !channel_is_armed(id))
+            {
+                file_bufs_[id].reset_transfer_config();
+                f_rewind(&fils_[id]);
+            } // Keep going.
+            // Skip if channel is active but buffer hasn't switched yet.
             if (idle_buffers_[id] == file_bufs_[id].get_idle_buffer())
                 continue;
 
@@ -220,7 +251,7 @@ public:
             // Transfer data from card to double-buffer.
             fr = f_read(&fils_[id], idle_buffers_[id], SD_CHUNK_SIZE, &bytes_read);
             if (fr != FR_OK)
-                {panic("Could not read the data: %s", filenames[id]);}
+                {panic("Could not read the data: %s", filenames_[id]);}
             if (!f_eof(&fils_[id])) // TODO: also handle reading subset of file.
                 continue;
             // Handle end-of-file.
@@ -231,7 +262,7 @@ public:
                 // Next transfer will be the last transfer.
                 file_bufs_[id].setup_last_dma_transfer(bytes_read);
                 idle_buffers_[id] = nullptr; // Trigger a re-arm on next update.
-                f_rewind(&fils_[id]);
+                //f_rewind(&fils_[id]); // gets handled on next iteration.
                 continue;
             }
             // Handle endless/many-iteration transfer condition.
@@ -247,21 +278,20 @@ public:
         }
     }
 
-
-
 private:
     // TODO: mark all data structures as __not_in_flash
     std::array<PIO_LTC264x, NUM_CHANNELS>& dacs_;
     std::array<const char*, NUM_CHANNELS>& filenames_;
     std::array<T*, NUM_CHANNELS> idle_buffers_;
-    FATFS filesystem_;
-    std::array<FIL, NUM_CHANNELS> __not_in_flash("file_handlers") fils_;
+    std::array<FIL, NUM_CHANNELS> fils_;
+    std::array<FIL*, NUM_CHANNELS> filptrs_;
     etl::vector<DMADoubleBuffer<T, BUF_SIZE>, NUM_CHANNELS> file_bufs_;
     std::array<WaveformSettings, NUM_CHANNELS> settings_;
     int dma_timer_chan_;
     dreq_num_t timer_pacing_signal_;
 
-    inline constexpr size_t SD_CHUNK_SIZE = BUF_SIZE * sizeof(T); // in bytes.
-    inline constexpr size_t DEFAULT_FREQUENCY_HZ = 500000;
+    static inline constexpr size_t SD_CHUNK_SIZE = BUF_SIZE * sizeof(T); // in bytes.
+    static inline constexpr size_t DEFAULT_FREQUENCY_HZ = 500000;
+    static inline constexpr uint16_t OUTPUT_MIDSCALE = 32768;
 };
 #endif // MULTI_FILE_PLAYER_H

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -35,6 +35,8 @@ public:
             file_bufs_.emplace_back(timer_pacing_signal_, &pio->txf[sm]);
         }
         std::ranges::fill(filptrs_, nullptr); // mark files as starting closed.
+        std::ranges::fill(curr_iterations_, 0);
+        std::ranges::fill(iterations_, 1);
         reset(); // Open files; reset the buffer loop.
     }
 
@@ -65,9 +67,8 @@ public:
         // TODO: maybe validate that the abort took place?
         for (auto& dac: dacs_)
             dac.write_value(OUTPUT_MIDSCALE);
-        // reset all file pointers.
-        for (size_t i = 0; i < NUM_CHANNELS; ++i)
-            idle_buffers_[i] = nullptr; // Clear local buffer value.
+        std::ranges::fill(idle_buffers_, nullptr); // Clear local buffer value.
+        std::ranges::fill(curr_iterations_, 0);
         cleanup(); // close all files.
     }
 
@@ -95,7 +96,7 @@ public:
     {
         FRESULT fr = f_close(&fils_[file_index]);
         if (fr != FR_OK)
-            panic("Could not close: fils_[%s].", i);
+            panic("Could not close: %s\r\n.", filenames_[file_index]);
         filptrs_[file_index] = nullptr; // clear ptr to indicate closed file.
     }
 
@@ -106,7 +107,7 @@ public:
     {
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
-            if !file_is_open(id)
+            if (!file_is_open(id))
                 continue;
             close_file(id);
         }
@@ -118,17 +119,23 @@ public:
  */
     void set_frequency_hz(uint32_t frequency_hz)
     {
-        uint32_t SYS_CLOCK_HZ = SYS_CLOCK_MHZ * 1'000'000;
-        float divisor = float(SYS_CLOCK_HZ) / frequency_hz;
+        float divisor = float(SYS_CLK_HZ) / frequency_hz;
         if (round(divisor) != divisor)
         {panic("Update frequency (%f [Hz]) must be a multiple of sys clock: %d",
-                SYS_CLOCK_MHZ);}
+                SYS_CLK_HZ);}
         // TODO: enable more flexible pacing options by allocating timers
         //  on-demand and sharing timers for matching frequencies, and
         //  respecting max number of used timers.
         //  Requires re-attaching timers to buffers.
         dma_timer_set_fraction(dma_timer_chan_, 1, divisor);
     }
+
+/**
+ * \brief
+ * \warning not multicore safe.
+ */
+    void set_channel_iterations(size_t channel_index, size_t iterations)
+    {iterations_[channel_index]= iterations;}
 
 /**
  * \brief start one or more channels specified as bitfields.
@@ -138,6 +145,7 @@ public:
     {
         // TODO: maybe make this fn return a bool in case we're not ready (armed)?
         // Create a trigger mask to start all Double Buffer DMA channels at once.
+        uint32_t multi_channel_trigger_mask = 0;
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
         {
             if ((channel_mask & (1u << i)) == 0)
@@ -206,7 +214,7 @@ public:
  * \brief true if channel is transferring data to its respective DAC.
  *  False otherwise (paused or aborted).
  */
-    void channel_is_active(size_t channel_index)
+    inline bool channel_is_active(size_t channel_index)
     {return file_bufs_[channel_index].is_transferring();}
 
 /**
@@ -231,9 +239,10 @@ public:
     void update()
     {
         // TODO: deadlne check between SD read iterations to ensure buffers are topped off.
+        FRESULT fr;
+        UINT bytes_read;
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
-            FRESULT fr;
             // Skip if channel is ready but not transferring.
             if (!channel_is_active(id) && channel_is_armed(id))
                 continue;
@@ -255,9 +264,9 @@ public:
             if (!f_eof(&fils_[id])) // TODO: also handle reading subset of file.
                 continue;
             // Handle end-of-file.
-             ++curr_iterations_[i]; // increment full file read iterations.
+             ++curr_iterations_[id]; // increment full file read iterations.
             // Handle last transfer condition.
-            if ((curr_iterations_[id] == iterations_[id]) && (iterations_[id] != 0)
+            if ((curr_iterations_[id] == iterations_[id]) && (iterations_[id] != 0))
             {
                 // Next transfer will be the last transfer.
                 file_bufs_[id].setup_last_dma_transfer(bytes_read);
@@ -285,6 +294,8 @@ private:
     std::array<T*, NUM_CHANNELS> idle_buffers_;
     std::array<FIL, NUM_CHANNELS> fils_;
     std::array<FIL*, NUM_CHANNELS> filptrs_;
+    std::array<size_t, NUM_CHANNELS> iterations_;
+    std::array<size_t, NUM_CHANNELS> curr_iterations_;
     etl::vector<DMADoubleBuffer<T, BUF_SIZE>, NUM_CHANNELS> file_bufs_;
     std::array<WaveformSettings, NUM_CHANNELS> settings_;
     int dma_timer_chan_;

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -37,7 +37,7 @@ public:
         std::ranges::fill(filptrs_, nullptr); // mark files as starting closed.
         std::ranges::fill(curr_iterations_, 0);
         std::ranges::fill(iterations_, 1);
-        reset(); // Open files; reset the buffer loop.
+        reset();
     }
 
 /**
@@ -218,13 +218,15 @@ public:
     {return file_bufs_[channel_index].is_transferring();}
 
 /**
- * \brief true if any channels are active.
+ * \brief true if any channel needs to be handled with periodic calls to update().
  */
     bool is_busy()
     {
-        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
-            if (channel_is_active(i))
+            if (channel_is_active(id))
+                return true;
+            else if (!channel_is_armed(id))
                 return true;
         }
         return false;
@@ -244,14 +246,31 @@ public:
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
             // Skip if channel is ready but not transferring.
-            if (!channel_is_active(id) && channel_is_armed(id))
-                continue;
-            // Handle playback-finished or playback-aborted condition
-            if (!channel_is_active(id) && !channel_is_armed(id))
+            bool channel_active = channel_is_active(id);
+            bool channel_armed = channel_is_armed(id);
+            if (!channel_active && channel_armed)
             {
+                //printf("not active and armed!\r\n");
+                continue;
+            }
+            // Handle playback-finished or playback-aborted condition
+            if (!channel_active && !channel_armed)
+            {
+                //printf("not active but not armed! needs rewind\r\n");
                 file_bufs_[id].reset_transfer_config();
+/*
+                PIO& pio = dacs_[id].get_pio();
+                int32_t sm = dacs_[id].get_sm();
+                file_bufs_[id].setup_transfer(timer_pacing_signal_, &pio->txf[sm]);
+*/
+
                 f_rewind(&fils_[id]);
             } // Keep going.
+
+            // Skip if we setup last DMA transfer, but it hasn't finished yet.
+            if (channel_active && file_bufs_[id].dma_chain_loop_disconnected())
+                continue;
+
             // Skip if channel is active but buffer hasn't switched yet.
             if (idle_buffers_[id] == file_bufs_[id].get_idle_buffer())
                 continue;
@@ -259,8 +278,9 @@ public:
             idle_buffers_[id] = file_bufs_[id].get_idle_buffer();
             // Transfer data from card to double-buffer.
             fr = f_read(&fils_[id], idle_buffers_[id], SD_CHUNK_SIZE, &bytes_read);
+            //printf("fptr: %llu\r\n", fils_[id].fptr);
             if (fr != FR_OK)
-                {panic("Could not read the data: %s", filenames_[id]);}
+                {panic("Could not read data from: %s", filenames_[id]);}
             if (!f_eof(&fils_[id])) // TODO: also handle reading subset of file.
                 continue;
             // Handle end-of-file.
@@ -269,9 +289,10 @@ public:
             if ((curr_iterations_[id] == iterations_[id]) && (iterations_[id] != 0))
             {
                 // Next transfer will be the last transfer.
+                //printf("EOF at %llu. Setting up last transfer\r\n", fils_[id].fptr);
                 file_bufs_[id].setup_last_dma_transfer(bytes_read);
                 idle_buffers_[id] = nullptr; // Trigger a re-arm on next update.
-                //f_rewind(&fils_[id]); // gets handled on next iteration.
+                curr_iterations_[id] = 0; // reset counter for next round.
                 continue;
             }
             // Handle endless/many-iteration transfer condition.

--- a/firmware/inc/waveform_settings.h
+++ b/firmware/inc/waveform_settings.h
@@ -1,0 +1,37 @@
+#ifndef WAVEFORM_SETTINGS_H
+#define WAVEFORM_SETTINGS_H
+
+
+struct WaveformSettings
+{
+    uint32_t iterations; // 0 for loops-forever.
+    uint32_t sample_count;
+    uint32_t frequency_hz;
+    uint8_t external_triggers;
+    //uint8_t sha256[8];
+
+    // TODO: default constructor should set iterations=1
+};
+
+// TODO: should commands be enums, and the actual command is a struct of
+//  {cmd, mask}?
+struct BulkWaveformCommands
+{
+    uint8_t start;
+    uint8_t pause;
+    uint8_t abort;
+    uint8_t arm;
+};
+
+
+/// Each bit represents a waveform.
+//struct BulkWaveformStates
+//{
+//    uint8_t is_armed;   // waveform[i] is ready (buffered) to be started.
+//    uint8_t is_playing; // waveform[i] is playing .
+//    uint8_t is_short_circuited; // waveform[i] short-circuit detection triggered.
+//};
+
+
+
+#endif // WAVEFORM_SETTINGS_H

--- a/firmware/src/core1_file_player.cpp
+++ b/firmware/src/core1_file_player.cpp
@@ -1,0 +1,48 @@
+#include <core1_file_player.h>
+
+void setup_file_player()
+{
+    // Setup DACs. First PIO_LTC264x loads the program; the others share it.
+    const std::array<PIO_LTC264x, NUM_CHANNELS> dacs
+    {{{pio2, DAC_PINS[0].sck, DAC_PINS[0].pico},
+      {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
+      {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},
+      {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()}}};
+    for (const auto& dac: dacs)
+        dac.start();
+
+    MultiFilePlayer player(dacs, filenames);
+}
+
+
+int core1main()
+{
+    WaveformSettings settings;
+    BulkWaveformStates last_bulk_state;
+
+    setup_file_player();
+    BulkWaveformStates last_bulk_state = player.get_bulk_state();
+    // Note: Commands like Pause/Resume/Stop are handled by core0.
+    while (true)
+    {
+        // Handle user waveform settings input from core0.
+        //Settings settings;
+        while (queue_try_remove(&waveform_settings_queue, &bulk_settings)
+        {
+            // apply new settings.
+            // TODO: Can you apply these while the waveform is playing??
+        }
+        // update file player loop: top off buffers, add/remove files.
+        update();
+        // TODO: If waveform finished, push finish time to core0.
+        //  Or consider attaching the interrupt on core0??
+
+        //// If the state changes between updates, push it back to core0;
+        //BulkWaveformStates curr_bulk_state = player.get_bulk_state();
+        //if (curr_bulk_state != last_bulk_state)
+        //{
+        //    queue_try_add(&bulk_waveform_states_queue, curr_bulk_state);
+        //    last_bulk_state = curr_bulk_state;
+        //}
+    }
+}

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,489 +1,70 @@
 #include <cstring>
 #include <harp_c_app.h>
 #include <harp_synchronizer.h>
-#include <core_registers.h>
 #include <reg_types.h>
 #include <config.h>
-#include <stdio.h>
-#include <cstdio> // for printf
-#include "hardware/flash.h"
-#include "hardware/timer.h"
-#include "hardware/clocks.h"
-#include "hardware/pll.h"
-#include "hardware/clocks.h"
-#include "hardware/structs/pll.h"
-#include "hardware/structs/clocks.h"
-#include "hardware/irq.h"
-
-
+#include <pio_ltc264x.h>
 #ifdef DEBUG
     #include <pico/stdlib.h> // for uart printing
     #include <cstdio> // for printf
 #endif
 
-#define DEBUG_HARP_MSG_IN
+inline constexpr size_t NUM_APP_REGS = 0;
 
-#define FLASH_TARGET_OFFSET (256 * 1024)  // Start writing at 256KB  = 
-#define SECTOR_SIZE FLASH_SECTOR_SIZE     // 4096 bytes
-#define BUF_SIZE 64
-// Define your constants and buffers
-#define TOTAL_DATA_SIZE 102400 // This is the total number of bytes
-#define TOTAL_16BIT_WORDS (TOTAL_DATA_SIZE / 2) // Total number of 16-bit words
-// Temporary buffer for each incoming USB packet (64 bytes)
-uint8_t rx_packet_buffer[BUF_SIZE];
-// Main buffer to store the complete 16-bit data
-uint16_t rx_data_buffer[TOTAL_16BIT_WORDS];
-bool write_to_flash = false;
-// Keep track of how much data we've received
-static uint32_t bytes_received = 0;
-static uint16_t words_received = 0;
-uint32_t count;
-
-uint32_t clock_sys;
-// Buffers for data transfer
-uint8_t read_data_buffer[100];
-
-uint8_t channel_index_wave;
-// Create device name array.
-const uint16_t who_am_i = 1234;
-const uint8_t hw_version_major = 0;
-const uint8_t hw_version_minor = 0;
-const uint8_t assembly_version = 0;
-const uint8_t harp_version_major = 0;
-const uint8_t harp_version_minor = 0;
-const uint8_t fw_version_major = 0;
-const uint8_t fw_version_minor = 0;
-const uint16_t serial_number = 0xCAFE;
-
-absolute_time_t time_current;
-// Harp App Register Setup.
-const size_t reg_count = 18;
-
-void write_any_channel(msg_t& msg);
-void erase_flash_memory(msg_t& msg);
-void specific_any_waveform(msg_t& msg);
-
-// Define the initial periods for the four alarms in microseconds (µs)
-#define ALARM_0_PERIOD_US 500000 // 500 ms
-#define ALARM_1_PERIOD_US 250000 // 250 ms
-#define ALARM_2_PERIOD_US 100000 // 100 ms 
-#define ALARM_3_PERIOD_US 50000  // 50 ms
-
-// Global state tracking and periods - periods must be volatile
 
 // Define register contents.
 #pragma pack(push, 1)
 struct app_regs_t
 {
-    volatile uint8_t start_channel_1;  // app register 0
-    volatile uint8_t start_channel_2;
-    volatile uint8_t start_channel_3; 
-    volatile uint8_t start_channel_4;
-
-    volatile uint8_t stop_channel_1;
-    volatile uint8_t stop_channel_2;
-    volatile uint8_t stop_channel_3; 
-    volatile uint8_t stop_channel_4;
-
-    volatile uint8_t one_shot_continous;
-    
-    volatile uint32_t update_rate_1;
-    volatile uint32_t update_rate_2;
-    volatile uint32_t update_rate_3; 
-    volatile uint32_t update_rate_4; 
-
-    volatile uint32_t samples_wave_1;
-    volatile uint32_t samples_wave_2;
-    volatile uint32_t samples_wave_3; 
-    volatile uint32_t samples_wave_4; 
-
-    volatile uint8_t erase_flash;
+    // TODO
 } app_regs;
 #pragma pack(pop)
 
-// This array now holds the current, modifiable periods
-volatile uint32_t alarm_periods[4] = {
-    ALARM_0_PERIOD_US, ALARM_1_PERIOD_US, ALARM_2_PERIOD_US, ALARM_3_PERIOD_US
-};
-
-// Next target time for each alarm
-static uint64_t target_time[4];
-
-// --- Helper Function to Dynamically Change the Interrupt Time ---
-void set_alarm_period(int alarm_num, uint32_t new_period_us) {
-    if (alarm_num < 0 || alarm_num > 3) return;
-
-    // Disable interrupts briefly to ensure an atomic update
-    uint32_t save = save_and_disable_interrupts();
-    
-    // Update the global period variable for the specified alarm
-    alarm_periods[alarm_num] = new_period_us;
-    
-    // Re-enable interrupts
-    restore_interrupts(save);
-
-    printf("Alarm %d period changed to %u us.\n", alarm_num, new_period_us);
-}
-
-// --- Alarm Interrupt Service Routines (ISRs) ---
-
-// --- Alarm 0 Interrupt Service Routine (ISR) ---
-static void timer_alarm_0_handler(void) {
-    hw_clear_bits(&timer_hw->intr, 1u << 0);
-    time_current = get_absolute_time();
-    target_time[0] += alarm_periods[0];
-    timer_hw->alarm[0] = target_time[0];
-    if (app_regs.one_shot_continous == 1)
-    {
-        // send data one shot
-    }
-    else
-    {
-        // send data one continously
-    }
-
-}
-
-// --- Alarm 1 Interrupt Service Routine (ISR) ---
-static void timer_alarm_1_handler(void) {
-    hw_clear_bits(&timer_hw->intr, 1u << 1);
-    time_current = get_absolute_time();
-    target_time[1] += alarm_periods[1];
-    timer_hw->alarm[1] = target_time[1];
-    if (app_regs.one_shot_continous == 1)
-    {
-        // send data one shot
-    }
-    else
-    {
-        // send data one continously
-    }
-
-}
-
-// --- Alarm 2 Interrupt Service Routine (ISR) ---
-static void timer_alarm_2_handler(void) {
-    hw_clear_bits(&timer_hw->intr, 1u << 2);
-    target_time[2] += alarm_periods[2];
-    timer_hw->alarm[2] = target_time[2];
-    if (app_regs.one_shot_continous == 1)
-    {
-        // send data one shot
-    }
-    else
-    {
-        // send data one continously
-    }
-
-}
-
-// --- Alarm 3 Interrupt Service Routine (ISR) ---
-static void timer_alarm_3_handler(void) {
-    hw_clear_bits(&timer_hw->intr, 1u << 3);
-    target_time[3] += alarm_periods[3];
-    timer_hw->alarm[3] = target_time[3];
-    if (app_regs.one_shot_continous == 1)
-    {
-        // send data one shot
-    }
-    else
-    {
-        // send data one continously
-    }
-
-}
-
-
-void init_alarm(int alarm_num, void (*handler_fn)(void), uint32_t period_us) {
-    
-    // Use the value stored in the global array for initial setup
-    target_time[alarm_num] = timer_hw->timerawl + alarm_periods[alarm_num];
-    timer_hw->alarm[alarm_num] = target_time[alarm_num];
-
-    // Set the interrupt handler and enable the IRQ
-    irq_set_exclusive_handler(TIMER_IRQ_0 + alarm_num, handler_fn);
-    irq_set_enabled(TIMER_IRQ_0 + alarm_num, true);
-
-    // Tell the timer hardware to fire an interrupt (set the interrupt enable bit)
-    timer_hw->inte |= 1u << alarm_num;
-}
-
-
-
-// Function to call the flash programming
-// Note: The flash programming function still works with 8-bit bytes
-static void call_flash_range_program(void *params) {
-    uintptr_t *p = (uintptr_t *)params;
-    flash_range_program(p[0], (const uint8_t*)p[1], TOTAL_DATA_SIZE);
-}
-
 
 // Define register "specs."
-RegSpecs app_reg_specs[reg_count]
+RegSpecs app_reg_specs[NUM_APP_REGS]
 {
-    {(uint8_t*)&app_regs.start_channel_1, sizeof(app_regs.start_channel_1), U8},
-    {(uint8_t*)&app_regs.start_channel_2, sizeof(app_regs.start_channel_2), U8},
-    {(uint8_t*)&app_regs.start_channel_3, sizeof(app_regs.start_channel_3), U8},
-    {(uint8_t*)&app_regs.start_channel_4, sizeof(app_regs.start_channel_4), U8},
-    {(uint8_t*)&app_regs.stop_channel_1, sizeof(app_regs.stop_channel_1), U8},
-    {(uint8_t*)&app_regs.stop_channel_2, sizeof(app_regs.stop_channel_2), U8},
-    {(uint8_t*)&app_regs.stop_channel_3, sizeof(app_regs.stop_channel_3), U8},
-    {(uint8_t*)&app_regs.stop_channel_4, sizeof(app_regs.stop_channel_4), U8},
-    {(uint8_t*)&app_regs.one_shot_continous, sizeof(app_regs.one_shot_continous), U8},
-
-    {(uint8_t*)&app_regs.update_rate_1, sizeof(app_regs.update_rate_1), U32},
-    {(uint8_t*)&app_regs.update_rate_2, sizeof(app_regs.update_rate_2), U32},
-    {(uint8_t*)&app_regs.update_rate_3, sizeof(app_regs.update_rate_3), U32},
-    {(uint8_t*)&app_regs.update_rate_4, sizeof(app_regs.update_rate_4), U32},
-    {(uint8_t*)&app_regs.samples_wave_1, sizeof(app_regs.samples_wave_1), U32},
-    {(uint8_t*)&app_regs.samples_wave_2, sizeof(app_regs.samples_wave_2), U32},
-    {(uint8_t*)&app_regs.samples_wave_3, sizeof(app_regs.samples_wave_3), U32},
-    {(uint8_t*)&app_regs.samples_wave_4, sizeof(app_regs.samples_wave_4), U32},
-    {(uint8_t*)&app_regs.erase_flash, sizeof(app_regs.erase_flash), U8}
+    // TODO
 };
 
 // Define register read-and-write handler functions.
-RegFnPair reg_handler_fns[reg_count]
+RegFnPair reg_handler_fns[NUM_APP_REGS]
 {
-    {&HarpCore::read_reg_generic, write_any_channel},
-    {&HarpCore::read_reg_generic, write_any_channel},
-    {&HarpCore::read_reg_generic, write_any_channel},
-    {&HarpCore::read_reg_generic, write_any_channel},
-    {&HarpCore::read_reg_generic, write_any_channel},
-    {&HarpCore::read_reg_generic, write_any_channel},
-    {&HarpCore::read_reg_generic, write_any_channel},
-    {&HarpCore::read_reg_generic, write_any_channel},
-
-    {&HarpCore::read_reg_generic, write_any_channel},
-    
-    {&HarpCore::read_reg_generic, specific_any_waveform},
-    {&HarpCore::read_reg_generic, specific_any_waveform},
-    {&HarpCore::read_reg_generic, specific_any_waveform},
-    {&HarpCore::read_reg_generic, specific_any_waveform},
-    {&HarpCore::read_reg_generic, specific_any_waveform},
-    {&HarpCore::read_reg_generic, specific_any_waveform},
-    {&HarpCore::read_reg_generic, specific_any_waveform},
-    {&HarpCore::read_reg_generic, specific_any_waveform},
-
-    {&HarpCore::read_reg_generic, erase_flash_memory}
+    // TODO
 };
-
-void write_any_channel(msg_t& msg)
-{
-    HarpCore::copy_msg_payload_to_register(msg);
-    uint8_t channel_index = msg.header.address - APP_REG_START_ADDRESS;
-}
-
-void specific_any_waveform(msg_t& msg)
-{
-    HarpCore::copy_msg_payload_to_register(msg);
-    channel_index_wave = msg.header.address - APP_REG_START_ADDRESS;
-    if(channel_index_wave == 8)
-        set_alarm_period(0, app_regs.update_rate_1);
-    else if(channel_index_wave == 9)
-        set_alarm_period(1, app_regs.update_rate_2);
-    else if(channel_index_wave == 10)
-        set_alarm_period(2, app_regs.update_rate_3);
-    else if(channel_index_wave == 11)
-        set_alarm_period(3, app_regs.update_rate_4);
-    printf("Set Interrupt Time intervals for Update Rate !\r\n");
-}
-
-void erase_flash_memory(msg_t& msg)
-{
-    HarpCore::copy_msg_payload_to_register(msg);
-    if(app_regs.erase_flash == 1)
-    {
-        printf("Erasing Flash Memory !\r\n");
-        uint32_t ints = save_and_disable_interrupts();
-        // for PI PICO RP2530
-        // we need to ereas (4 Mbyte - 256 Kbyte) = 3932160 byte 
-        // (write it in term of Sector_Size as follow  960*4*1024 = 3932160 bytes = 3840 Kbyte)
-        // flash_range_erase(FLASH_TARGET_OFFSET  , 960*SECTOR_SIZE);
-        // for PI PICO RP2040
-        // we need to ereas (2 Mbyte - 256 Kbyte) = 1835008 byte 
-        // (write it in term of Sector_Size as follow  448*4*1024 = 1835008 bytes = 1792 Kbyte)
-        flash_range_erase(FLASH_TARGET_OFFSET  , 448*SECTOR_SIZE);
-        // Restore interrupts
-        restore_interrupts(ints);
-        printf("Done Erasing Flash Memory !\r\n");
-    }
-}
 
 void app_reset()
 {
-    app_regs.start_channel_1 = 0;
-    app_regs.start_channel_2 = 0;
-    app_regs.start_channel_3 = 0;
-    app_regs.start_channel_4 = 0;
-
-    app_regs.stop_channel_1 = 0;
-    app_regs.stop_channel_2 = 0;
-    app_regs.stop_channel_3 = 0;
-    app_regs.stop_channel_4 = 0;
-
-    app_regs.update_rate_1 = 0;
-    app_regs.update_rate_2 = 0;
-    app_regs.update_rate_3 = 0;
-    app_regs.update_rate_4 = 0;
-
-    app_regs.samples_wave_1 = 0;
-    app_regs.samples_wave_2 = 0;
-    app_regs.samples_wave_3 = 0;
-    app_regs.samples_wave_4 = 0;
-
-    app_regs.erase_flash = 0;
-
+    // TODO
 }
 
-void update_app_state()
+void update_app()
 {
-    // update here!
-    printf("Hello, from an Quad DAC!\r\n");
-    // If app registers update their states outside the read/write handler
-    // functions, update them here.
-    // (Called inside run() function.)
-}
-#ifndef LED_DELAY_MS
-#define LED_DELAY_MS 100
-#endif
 
-#ifndef PICO_DEFAULT_LED_PIN
-#warning blink_simple example requires a board with a regular LED
-#endif
-
-// Initialize the GPIO for the LED
-void pico_led_init(void) {
-#ifdef PICO_DEFAULT_LED_PIN
-    // A device like Pico that uses a GPIO for the LED will define PICO_DEFAULT_LED_PIN
-    // so we can use normal GPIO functionality to turn the led on and off
-    gpio_init(PICO_DEFAULT_LED_PIN);
-    gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
-#endif
 }
 
-void gpio_callback(uint gpio, uint32_t events)
-{
-    uint32_t gpio_state = gpio_get_all();
-    /*app_regs.di_state = 0;
-    app_regs.di_state |= (gpio_state & 0xC) >> 2;
-    app_regs.di_state |= (gpio_state & 0x7000) >> 10;
-    */
-    HarpCore::send_harp_reply(EVENT, APP_REG_START_ADDRESS);
-}
-
-void configure_gpio(void)
-{
-    gpio_set_irq_callback(gpio_callback);
-}
-
-// Turn the LED on or off
-void pico_set_led(bool led_on) {
-#if defined(PICO_DEFAULT_LED_PIN)
-    // Just set the GPIO on or off
-    gpio_put(PICO_DEFAULT_LED_PIN, led_on);
-#endif
-}
 // Create Harp App.
 HarpCApp& app = HarpCApp::init(HARP_DEVICE_ID,
                                HW_VERSION_MAJOR, HW_VERSION_MINOR,
                                HW_ASSEMBLY_VERSION,
                                HARP_VERSION_MAJOR, HARP_VERSION_MINOR,
                                FW_VERSION_MAJOR, FW_VERSION_MINOR,
-                               UNUSED_SERIAL_NUMBER, "Quad DAC",
+                               UNUSED_SERIAL_NUMBER,
+                               "quac",
                                (uint8_t*)GIT_HASH,
                                &app_regs, app_reg_specs,
-                               reg_handler_fns, reg_count, update_app_state,
+                               reg_handler_fns, NUM_APP_REGS, update_app,
                                app_reset);
 
 // Core0 main.
 int main()
 {
-    pico_led_init();
 // Init Synchronizer.
     HarpSynchronizer::init(uart1, HARP_SYNC_RX_PIN);
     app.set_synchronizer(&HarpSynchronizer::instance());
-    configure_gpio();
     #ifdef DEBUG
     stdio_uart_init_full(uart0, 921600, UART_TX_PIN, -1); // use uart1 tx only.
-    printf("Hello, from Quad DAC!\r\n");
+    printf("Hello, from the quac board!\r\n");
 #endif
 
-// Re init uart now that clk_peri has changed
-/*
-stdio_init_all();
-
-// --- Timer Setup ---
-// Initialize all four alarms with their initial periods
-init_alarm(0, timer_alarm_0_handler, ALARM_0_PERIOD_US);
-init_alarm(1, timer_alarm_1_handler, ALARM_1_PERIOD_US);
-init_alarm(2, timer_alarm_2_handler, ALARM_2_PERIOD_US);
-init_alarm(3, timer_alarm_3_handler, ALARM_3_PERIOD_US);
-
-    while(true)
-    {
-        // printf("Hello, from Quad DAC!\r\n");
-
-        if (tud_vendor_available()) {
-            uint32_t count = tud_vendor_read(rx_packet_buffer, sizeof(rx_packet_buffer));
-
-            // Ensure the data size is an even number for 16-bit conversion
-            if (count % 2 != 0) {
-                printf("Error: Received odd number of bytes, 16-bit data expected.\n");
-                bytes_received = 0;
-                words_received = 0;
-                continue;
-            }
-
-            // Check if we have enough space in our main buffer (in bytes)
-            if (bytes_received + count <= TOTAL_DATA_SIZE) {
-                // Manually convert 8-bit bytes into 16-bit words
-                for (uint32_t i = 0; i < count; i += 2) {
-                    // Combine two 8-bit bytes into a single 16-bit word
-                    rx_data_buffer[words_received] = (uint16_t)rx_packet_buffer[i] | ((uint16_t)rx_packet_buffer[i + 1] << 8);
-                    words_received++;
-                }
-                bytes_received += count;
-
-                if (bytes_received == TOTAL_DATA_SIZE) {
-                    write_to_flash = true;
-                    printf("Full 16-bit data array received, preparing to write to flash.\n");
-                }
-            } else {
-                printf("Error: Buffer overflow. Data dropped.\n");
-                bytes_received = 0;
-                words_received = 0;
-            }
-        }
-
-        if (write_to_flash) {
-            uintptr_t params[] = {FLASH_TARGET_OFFSET, (uintptr_t)rx_data_buffer};
-            uint32_t rc;
-
-            printf("Writing to flash... DO NOT unplug.\n");
-            // Cast the 16-bit buffer to a void pointer for the flash function
-            rc = flash_safe_execute(call_flash_range_program, params, TOTAL_DATA_SIZE);
-
-            if (rc == PICO_OK) {
-                printf("Flash write completed successfully.\n");
-                const uint8_t *flash_read_address = (const uint8_t *)(XIP_BASE + FLASH_TARGET_OFFSET);
-
-                memcpy(read_data_buffer, flash_read_address, 100);
-
-                printf("Read for 16-bit data...\n");
-            } else {
-                printf("Flash write failed with error code: %d\n", rc);
-            }
-            
-            bytes_received = 0;
-            words_received = 0;
-            write_to_flash = false;
-        }
-            app.run();
-        // time_current = get_absolute_time();
-        // time_current = get_absolute_time();
-        // clock_sys = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_SYS);
-        
-    }
-*/
 }

--- a/firmware/src/sd_hw_config.cpp
+++ b/firmware/src/sd_hw_config.cpp
@@ -1,0 +1,36 @@
+#include <hw_config.h> // from no-os* sd card library.
+#include <config.h>
+
+static sd_sdio_if_t SD_SDIO_INTERFACE
+{
+    // Pins CLK_gpio, D1_gpio, D2_gpio, and D3_gpio are relative to pin D0_gpio.
+
+//  CLK_gpio = D0_gpio - 2; -> derived from D0_gpio.
+    .CMD_gpio = SD_CMD_PIN,
+    .D0_gpio = SD_D0_PIN,
+//    D1_gpio = D0_gpio + 1; -> derived from D0_gpio.
+//    D2_gpio = D0_gpio + 2; -> derived from D0_gpio.
+//    D3_gpio = D0_gpio + 3; -> derived from D0_gpio.
+    .SDIO_PIO = SD_PIO,
+    .baud_rate = SD_READ_SPEED_HZ
+                                        // RP2040: */6 -> 20833333 Hz
+};
+
+static sd_card_t SDCard
+{
+    .type = SD_IF_SDIO,
+    .sdio_if_p = &SD_SDIO_INTERFACE // interface spec from config.h
+};
+
+// Function implementations for definitions in hw_config.h.
+// These must be defined for the fatfs calls to work per this project's spec.
+
+size_t sd_get_num()
+{return 1;}
+
+sd_card_t* sd_get_by_num(size_t num)
+{
+    if (num == 0)
+        return &SDCard;
+    return nullptr;
+}

--- a/firmware/tests/abort/CMakeLists.txt
+++ b/firmware/tests/abort/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.13)
+find_package(Git REQUIRED)
+execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD OUTPUT_VARIABLE COMMIT_ID OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(STATUS "Computed Git Hash: ${COMMIT_ID}")
+add_definitions(-DGIT_HASH="${COMMIT_ID}") # Usable in source code.
+
+#add_definitions(-DDEBUG) # Uncomment for debugging
+
+set(PICO_BOARD pico2)
+set(PICO_PLATFORM rp2350-arm-s)
+
+if (DEFINED PICO_SDK_PATH)
+    message("Using explicitly defined PICO_SDK_PATH.")
+elseif (DEFINED ENV{PICO_SDK_PATH} AND NOT DEFINED PICO_SDK_PATH)
+    set(PICO_SDK_PATH "$ENV{PICO_SDK_PATH}")
+    add_definitions(-DPICO_SDK_PATH="$ENV{PICO_SDK_PATH}")
+    message("Using environment variable PICO_SDK_PATH.")
+else()
+    message(SEND_ERROR "PICO_SDK_PATH is not defined either as an environment "
+"variable or explicitly via 'cmake -DPICO_SDK_PATH=<path to pico sdk> ..'")
+endif()
+include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+set(CMAKE_CXX_STANDARD 20)
+project(abort)
+
+pico_sdk_init()
+
+#add_compile_definitions(USE_PRINTF) # For debugging no-os-* library.
+
+add_subdirectory(../../lib/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src lib_build/no_os_fatfs_sd_sdio_spi_rpi_pico)
+add_subdirectory(../../lib/rp2040.pio-ltc264x lib_build/pio-ltc264x)
+
+
+add_library(dma_double_buffer INTERFACE)
+target_sources(dma_double_buffer INTERFACE
+    ../../inc/dma_double_buffer.h
+)
+
+add_executable(${PROJECT_NAME}
+    src/main.cpp
+)
+
+include_directories(../../inc)
+
+target_link_libraries(${PROJECT_NAME}
+    pico_stdlib
+    pio_ltc264x
+    no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
+    dma_double_buffer
+)
+
+pico_add_extra_outputs(${PROJECT_NAME})
+
+pico_enable_stdio_usb(${PROJECT_NAME} 1)

--- a/firmware/tests/abort/src/main.cpp
+++ b/firmware/tests/abort/src/main.cpp
@@ -36,6 +36,10 @@ int main() {
     // Create double-buffer. Note: buffer is sized in T-size, not byte size.
     DMADoubleBuffer<T, WORD_COUNT> buf(pacing_signal, &pio2->txf[dac.get_sm()]);
 
+    // Sanity check.
+    if (buf.is_aborted())
+        printf("ERROR: Buffer detected as aborted before even transferring.\r\n");
+
     // Copy of the current idle buffer name so we can track when it toggles.
     printf("Starting transfer.\r\n");
     buf.setup_last_dma_transfer(WORD_COUNT); // only do one buffer transfer.
@@ -44,11 +48,23 @@ int main() {
     printf("Waiting for transfer to start.\r\n");
     while (!buf.is_transferring()){}
     sleep_ms(1);
+    printf("Aborting transfer.\r\n");
     buf.abort_transfer();
     if (!buf.is_transferring())
-        printf("Transfer aborted.\r\n");
+        printf("No longer transferring.\r\n");
+    else
+        printf("ERROR: Transfer is still transferring or detected as such.\r\n");
+    if (buf.is_aborted())
+        printf("Transfer detected as aborted.\r\n");
     else
         printf("ERROR: Transfer not aborted or not detected as such.\r\n");
-    printf("Transfer complete! Goodbye, world.\r\n");
+    printf("Resetting dma configuration.\r\n");
+    buf.reset_transfer_config();
+    if (buf.is_aborted())
+        printf("ERROR: Buffer still detected as aborted.\r\n");
+    else
+        printf("Buffer no longer detected as aborted.\r\n");
+
+    printf("Goodbye, world.\r\n");
     for (;;);
 }

--- a/firmware/tests/abort/src/main.cpp
+++ b/firmware/tests/abort/src/main.cpp
@@ -8,7 +8,6 @@
 #include "ff.h"
 #include "hw_config.h"
 
-inline constexpr uint32_t PAUSE_INTERVAL_US = 500000;
 inline constexpr uint32_t WORD_COUNT = 32768;
 
 using T = uint16_t;
@@ -41,32 +40,15 @@ int main() {
     printf("Starting transfer.\r\n");
     buf.setup_last_dma_transfer(WORD_COUNT); // only do one buffer transfer.
     buf.start_transfer();
-    uint32_t start_time_s = time_us_32();
-    uint32_t next_time_us = start_time_s + PAUSE_INTERVAL_US;
-    while (true)
-    {
-        while (int32_t(time_us_32() - next_time_us) < 0){}
-        if (buf.transfer_complete())
-            break;
-
-        next_time_us += PAUSE_INTERVAL_US;
-        buf.pause_transfer();
-        printf("Paused transfer.\r\n");
-        if (buf.is_paused())
-            printf("Transfer is now paused.\r\n");
-        else
-            printf("ERROR: Transfer not paused or not detected as paused.\r\n");
-
-        while (int32_t(time_us_32() - next_time_us) < 0){}
-
-        next_time_us += PAUSE_INTERVAL_US;
-        buf.resume_transfer();
-        printf("Resumed transfer.\r\n");
-        if (!buf.is_paused() || buf.transfer_complete())
-            printf("Transfer is now resumed.\r\n");
-        else
-            printf("ERROR: Transfer not resumed or not detected as resumed.\r\n");
-    }
+    // Wait for transfer to start. (Should be instant.)
+    printf("Waiting for transfer to start.\r\n");
+    while (!buf.is_transferring()){}
+    sleep_ms(1);
+    buf.abort_transfer();
+    if (!buf.is_transferring())
+        printf("Transfer aborted.\r\n");
+    else
+        printf("ERROR: Transfer not aborted or not detected as such.\r\n");
     printf("Transfer complete! Goodbye, world.\r\n");
     for (;;);
 }

--- a/firmware/tests/multi_file_player/CMakeLists.txt
+++ b/firmware/tests/multi_file_player/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
 endif()
 include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
 set(CMAKE_CXX_STANDARD 20)
-project(multi_file_player)
+project(test_multi_file_player)
 
 pico_sdk_init()
 
@@ -29,6 +29,7 @@ pico_sdk_init()
 
 add_subdirectory(../../lib/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src lib_build/no_os_fatfs_sd_sdio_spi_rpi_pico)
 add_subdirectory(../../lib/rp2040.pio-ltc264x lib_build/pio-ltc264x)
+add_subdirectory(../../lib/etl lib_build/etl)
 
 
 add_library(dma_double_buffer INTERFACE)
@@ -47,12 +48,13 @@ add_executable(${PROJECT_NAME}
 
 include_directories(../../inc)
 
-target_link_libraries(multi_file_player
+target_link_libraries(multi_file_player INTERFACE
     pico_stdlib
     pio_ltc264x
     no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
     multi_file_player
     dma_double_buffer
+    etl::etl
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/firmware/tests/multi_file_player/CMakeLists.txt
+++ b/firmware/tests/multi_file_player/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.13)
+find_package(Git REQUIRED)
+execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD OUTPUT_VARIABLE COMMIT_ID OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(STATUS "Computed Git Hash: ${COMMIT_ID}")
+add_definitions(-DGIT_HASH="${COMMIT_ID}") # Usable in source code.
+
+#add_definitions(-DDEBUG) # Uncomment for debugging
+
+set(PICO_BOARD pico2)
+set(PICO_PLATFORM rp2350-arm-s)
+
+if (DEFINED PICO_SDK_PATH)
+    message("Using explicitly defined PICO_SDK_PATH.")
+elseif (DEFINED ENV{PICO_SDK_PATH} AND NOT DEFINED PICO_SDK_PATH)
+    set(PICO_SDK_PATH "$ENV{PICO_SDK_PATH}")
+    add_definitions(-DPICO_SDK_PATH="$ENV{PICO_SDK_PATH}")
+    message("Using environment variable PICO_SDK_PATH.")
+else()
+    message(SEND_ERROR "PICO_SDK_PATH is not defined either as an environment "
+"variable or explicitly via 'cmake -DPICO_SDK_PATH=<path to pico sdk> ..'")
+endif()
+include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+set(CMAKE_CXX_STANDARD 20)
+project(multi_file_player)
+
+pico_sdk_init()
+
+#add_compile_definitions(USE_PRINTF) # For debugging no-os-* library.
+
+add_subdirectory(../../lib/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src lib_build/no_os_fatfs_sd_sdio_spi_rpi_pico)
+add_subdirectory(../../lib/rp2040.pio-ltc264x lib_build/pio-ltc264x)
+
+
+add_library(dma_double_buffer INTERFACE)
+target_sources(dma_double_buffer INTERFACE
+    ../../inc/dma_double_buffer.h
+)
+
+add_library(multi_file_player INTERFACE)
+target_sources(multi_file_player INTERFACE
+    ../../inc/multi_file_player.h
+)
+
+add_executable(${PROJECT_NAME}
+    src/main.cpp
+)
+
+include_directories(../../inc)
+
+target_link_libraries(multi_file_player
+    pico_stdlib
+    pio_ltc264x
+    no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
+    multi_file_player
+    dma_double_buffer
+)
+
+target_link_libraries(${PROJECT_NAME}
+    pico_stdlib
+    pio_ltc264x
+    multi_file_player
+)
+
+pico_add_extra_outputs(${PROJECT_NAME})
+
+pico_enable_stdio_usb(${PROJECT_NAME} 1)

--- a/firmware/tests/multi_file_player/src/main.cpp
+++ b/firmware/tests/multi_file_player/src/main.cpp
@@ -79,7 +79,7 @@ int main() {
     printf("Hello, world, from a Raspberry Pi Pico!\r\n");
 
     // Setup PIO Block for DAC communication.
-    const std::array<PIO_LTC264x, NUM_FILES> dacs
+    std::array<PIO_LTC264x, NUM_FILES> dacs
     {{{pio2, DAC_PINS[0].sck, DAC_PINS[0].pico},
       {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
       {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},

--- a/firmware/tests/multi_file_player/src/main.cpp
+++ b/firmware/tests/multi_file_player/src/main.cpp
@@ -1,0 +1,115 @@
+#include <stdio.h>
+#include <pico/stdlib.h>
+#include <hardware/dma.h>
+#include <hardware/pio.h>
+#include <pio_ltc264x.h>
+#include "config.h"
+
+using T = uint16_t;
+static constexpr size_t NUM_FILES = 4;
+static constexpr size_t SD_CHUNK_SIZE = 32768;  // must be factor of 512.
+
+FIL __not_in_flash("file_handlers") fil[NUM_FILES];
+inline constexpr std::array<const char*, NUM_FILES> filenames
+{{"channel_0.txt", "channel_1.txt", "channel_2.txt", "channel_3.txt"}};
+
+struct DACPins
+{
+    uint32_t pico;
+    uint32_t sck;
+    uint32_t cs;
+}
+
+inline constexpr std::array<DACPins, NUM_FILES> DAC_PINS
+{{
+    {.pico = 15, .sck = 16, .cs = 17},
+    {.pico = 18, .sck = 19, .cs = 20},
+    {.pico = 22, .sck = 23, .cs = 24},
+    {.pico = 25, .sck = 26, .cs = 27}
+}};
+
+/* SDIO Interface */
+static sd_sdio_if_t sdio_if = {
+//  CLK_gpio = D0_gpio - 2; -> derived from D0_gpio.
+    .CMD_gpio = 3,
+    .D0_gpio = 4,
+//    D1_gpio = D0_gpio + 1; -> derived from D0_gpio.
+//    D2_gpio = D0_gpio + 2; -> derived from D0_gpio.
+//    D3_gpio = D0_gpio + 3; -> derived from D0_gpio.
+    .SDIO_PIO = pio0,
+    .baud_rate = 150 * 1000 * 1000 / 5, // RP2350: */5 -> 30000000 Hz
+};
+
+/* Hardware Configuration of the SD Card socket "object" */
+static sd_card_t sd_card = {.type = SD_IF_SDIO, .sdio_if_p = &sdio_if};
+
+/**
+ * @brief Get the number of SD cards.
+ * @return The number of SD cards, which is 1 in this case.
+ */
+size_t sd_get_num() { return 1; }
+
+/**
+ * @brief Get a pointer to an SD card object by its number.
+ *
+ * @param[in] num The number of the SD card to get.
+ *
+ * @return A pointer to the SD card object, or @c NULL if the number is invalid.
+ */
+sd_card_t* sd_get_by_num(size_t num) {
+    if (0 == num)
+    {return &sd_card;}
+    else
+    {return NULL;}
+}
+
+int main() {
+    UINT bytes_read;
+
+    stdio_init_all();
+    while (!stdio_usb_connected()){ sleep_ms(100);} // Wait for user to open com port.
+    // Mount SD card.
+    FATFS fs;
+    FRESULT fr = f_mount(&fs, "", 1);
+    if (FR_OK != fr)
+    {panic("f_mount error: %s (%d)\n", FRESULT_str(fr), fr);}
+    printf("Hello, world, from a Raspberry Pi Pico!\r\n");
+
+    // Setup PIO Block for DAC communication.
+    const std::array<PIO_LTC264x, NUM_FILES> dacs
+    {{{pio2, SCK_PIN, PICO_PIN},
+      {pio2, SCK_PIN1, PICO_PIN1, false, dacs[0].get_offset()},
+      {pio2, SCK_PIN2, PICO_PIN2, false, dacs[0].get_offset()},
+      {pio2, SCK_PIN3, PICO_PIN3, false, dacs[0].get_offset()}}};
+    for (const auto& dac: dacs)
+        dac.start();
+
+    // FIXME: should MultiFilePlayer be doing this.
+    // Setup transfer rate for 500K words-per-sec. Assume soure clock of 150MHz.
+    int dma_timer_chan = dma_claim_unused_timer(true);
+    printf("Claimed DMA Timer %d.\r\n", dma_timer_chan);
+    dma_timer_set_fraction(dma_timer_chan, 1, 300); // numerator=1, denominator=300
+    dreq_num_t pacing_signal = dreq_num_t(dma_get_timer_dreq(dma_timer_chan));
+
+    // Create MultiFilePlayer
+    MultiFilePlayer<T, NUM_FILES, SD_CHUNK_SIZE/sizeof(T)> player(dacs, filenames);
+    for (size_t i = 0; i < NUM_FILES; ++i)
+        player.set_frequency_hz(i, 500000);
+    // FIXME: instead of calling update in a poll loop, we should be able to do
+    // one `player.init()` instead.
+    while (!player.is_armed(0b111))
+        player.update();    // Should only be one iteration.
+    player.start(0b1111);
+    while(player.is_busy())
+        player.update();
+    // We'll be back after a short break.
+    sleep_ms(1000);
+    // Retrigger all channels again.
+    player.start(0b1111);
+    while(player.is_busy())
+        player.update();
+
+    player.cleanup(); // Close files.
+    printf("All transfers complete! Goodbye, world!\r\n");
+    for (;;);
+}

--- a/firmware/tests/multi_file_player/src/main.cpp
+++ b/firmware/tests/multi_file_player/src/main.cpp
@@ -3,14 +3,19 @@
 #include <hardware/dma.h>
 #include <hardware/pio.h>
 #include <pio_ltc264x.h>
-#include "config.h"
+#include <array>
+#include <f_util.h>
+#include <ff.h>
+#include <hw_config.h>
+#include <multi_file_player.h>
 
 using T = uint16_t;
-static constexpr size_t NUM_FILES = 4;
-static constexpr size_t SD_CHUNK_SIZE = 32768;  // must be factor of 512.
+inline constexpr size_t NUM_FILES = 4;
+inline constexpr size_t SD_CHUNK_SIZE = 32768;  // must be factor of 512.
 
 FIL __not_in_flash("file_handlers") fil[NUM_FILES];
-inline constexpr std::array<const char*, NUM_FILES> filenames
+
+std::array<const char*, NUM_FILES> filenames
 {{"channel_0.txt", "channel_1.txt", "channel_2.txt", "channel_3.txt"}};
 
 struct DACPins
@@ -18,9 +23,9 @@ struct DACPins
     uint32_t pico;
     uint32_t sck;
     uint32_t cs;
-}
+};
 
-inline constexpr std::array<DACPins, NUM_FILES> DAC_PINS
+std::array<DACPins, NUM_FILES> DAC_PINS
 {{
     {.pico = 15, .sck = 16, .cs = 17},
     {.pico = 18, .sck = 19, .cs = 20},
@@ -51,9 +56,7 @@ size_t sd_get_num() { return 1; }
 
 /**
  * @brief Get a pointer to an SD card object by its number.
- *
  * @param[in] num The number of the SD card to get.
- *
  * @return A pointer to the SD card object, or @c NULL if the number is invalid.
  */
 sd_card_t* sd_get_by_num(size_t num) {
@@ -77,28 +80,17 @@ int main() {
 
     // Setup PIO Block for DAC communication.
     const std::array<PIO_LTC264x, NUM_FILES> dacs
-    {{{pio2, SCK_PIN, PICO_PIN},
-      {pio2, SCK_PIN1, PICO_PIN1, false, dacs[0].get_offset()},
-      {pio2, SCK_PIN2, PICO_PIN2, false, dacs[0].get_offset()},
-      {pio2, SCK_PIN3, PICO_PIN3, false, dacs[0].get_offset()}}};
+    {{{pio2, DAC_PINS[0].sck, DAC_PINS[0].pico},
+      {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
+      {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},
+      {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()}}};
     for (const auto& dac: dacs)
         dac.start();
 
-    // FIXME: should MultiFilePlayer be doing this.
-    // Setup transfer rate for 500K words-per-sec. Assume soure clock of 150MHz.
-    int dma_timer_chan = dma_claim_unused_timer(true);
-    printf("Claimed DMA Timer %d.\r\n", dma_timer_chan);
-    dma_timer_set_fraction(dma_timer_chan, 1, 300); // numerator=1, denominator=300
-    dreq_num_t pacing_signal = dreq_num_t(dma_get_timer_dreq(dma_timer_chan));
-
     // Create MultiFilePlayer
     MultiFilePlayer<T, NUM_FILES, SD_CHUNK_SIZE/sizeof(T)> player(dacs, filenames);
-    for (size_t i = 0; i < NUM_FILES; ++i)
-        player.set_frequency_hz(i, 500000);
-    // FIXME: instead of calling update in a poll loop, we should be able to do
-    // one `player.init()` instead.
-    while (!player.is_armed(0b111))
-        player.update();    // Should only be one iteration.
+    player.set_frequency_hz(500'000);
+    player.setup();
     player.start(0b1111);
     while(player.is_busy())
         player.update();
@@ -108,8 +100,9 @@ int main() {
     player.start(0b1111);
     while(player.is_busy())
         player.update();
-
     player.cleanup(); // Close files.
+    // Unmount the file system.
+    f_unmount("");
     printf("All transfers complete! Goodbye, world!\r\n");
     for (;;);
 }

--- a/firmware/tests/multi_file_player/src/main.cpp
+++ b/firmware/tests/multi_file_player/src/main.cpp
@@ -10,13 +10,15 @@
 #include <multi_file_player.h>
 
 using T = uint16_t;
-inline constexpr size_t NUM_FILES = 4;
+inline constexpr size_t NUM_FILES = 1;
 inline constexpr size_t SD_CHUNK_SIZE = 32768;  // must be factor of 512.
 
 FIL __not_in_flash("file_handlers") fil[NUM_FILES];
 
+//std::array<const char*, NUM_FILES> filenames
+//{{"channel_0.txt", "channel_1.txt", "channel_2.txt", "channel_3.txt"}};
 std::array<const char*, NUM_FILES> filenames
-{{"channel_0.txt", "channel_1.txt", "channel_2.txt", "channel_3.txt"}};
+{{"channel_0.txt"}};
 
 struct DACPins
 {
@@ -28,9 +30,9 @@ struct DACPins
 std::array<DACPins, NUM_FILES> DAC_PINS
 {{
     {.pico = 15, .sck = 16, .cs = 17},
-    {.pico = 18, .sck = 19, .cs = 20},
-    {.pico = 22, .sck = 23, .cs = 24},
-    {.pico = 25, .sck = 26, .cs = 27}
+//    {.pico = 18, .sck = 19, .cs = 20},
+//    {.pico = 22, .sck = 23, .cs = 24},
+//    {.pico = 25, .sck = 26, .cs = 27}
 }};
 
 /* SDIO Interface */
@@ -81,9 +83,10 @@ int main() {
     // Setup PIO Block for DAC communication.
     std::array<PIO_LTC264x, NUM_FILES> dacs
     {{{pio2, DAC_PINS[0].sck, DAC_PINS[0].pico},
-      {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
-      {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},
-      {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()}}};
+    //  {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
+    //  {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},
+    //  {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()}}};
+    }};
     for (const auto& dac: dacs)
         dac.start();
 
@@ -91,15 +94,23 @@ int main() {
     MultiFilePlayer<T, NUM_FILES, SD_CHUNK_SIZE/sizeof(T)> player(dacs, filenames);
     player.set_frequency_hz(500'000);
     player.setup();
+    printf("File Player is ready.\r\n");
+    sleep_ms(500);
+    printf("Starting.\r\n");
     player.start(0b1111);
     while(player.is_busy())
         player.update();
-    // We'll be back after a short break.
+    printf("Done playing!\r\n");
     sleep_ms(1000);
+
+    // If we did not abort, we should be able to re-trigger.
     // Retrigger all channels again.
+    printf("Restarting.\r\n");
     player.start(0b1111);
     while(player.is_busy())
         player.update();
+    printf("Done replaying! Closing files.\r\n");
+
     player.cleanup(); // Close files.
     // Unmount the file system.
     f_unmount("");

--- a/firmware/tests/pause_and_resume/CMakeLists.txt
+++ b/firmware/tests/pause_and_resume/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.13)
+find_package(Git REQUIRED)
+execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD OUTPUT_VARIABLE COMMIT_ID OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(STATUS "Computed Git Hash: ${COMMIT_ID}")
+add_definitions(-DGIT_HASH="${COMMIT_ID}") # Usable in source code.
+
+#add_definitions(-DDEBUG) # Uncomment for debugging
+
+set(PICO_BOARD pico2)
+set(PICO_PLATFORM rp2350-arm-s)
+
+if (DEFINED PICO_SDK_PATH)
+    message("Using explicitly defined PICO_SDK_PATH.")
+elseif (DEFINED ENV{PICO_SDK_PATH} AND NOT DEFINED PICO_SDK_PATH)
+    set(PICO_SDK_PATH "$ENV{PICO_SDK_PATH}")
+    add_definitions(-DPICO_SDK_PATH="$ENV{PICO_SDK_PATH}")
+    message("Using environment variable PICO_SDK_PATH.")
+else()
+    message(SEND_ERROR "PICO_SDK_PATH is not defined either as an environment "
+"variable or explicitly via 'cmake -DPICO_SDK_PATH=<path to pico sdk> ..'")
+endif()
+include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+set(CMAKE_CXX_STANDARD 20)
+project(pause_and_resume)
+
+pico_sdk_init()
+
+#add_compile_definitions(USE_PRINTF) # For debugging no-os-* library.
+
+add_subdirectory(../../lib/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src lib_build/no_os_fatfs_sd_sdio_spi_rpi_pico)
+add_subdirectory(../../lib/rp2040.pio-ltc264x lib_build/pio-ltc264x)
+
+
+add_library(dma_double_buffer INTERFACE)
+target_sources(dma_double_buffer INTERFACE
+    ../../inc/dma_double_buffer.h
+)
+
+add_executable(${PROJECT_NAME}
+    src/main.cpp
+)
+
+include_directories(../../inc)
+
+target_link_libraries(${PROJECT_NAME}
+    pico_stdlib
+    pio_ltc264x
+    no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
+    dma_double_buffer
+)
+
+pico_add_extra_outputs(${PROJECT_NAME})
+
+pico_enable_stdio_usb(${PROJECT_NAME} 1)

--- a/firmware/tests/pause_and_resume/src/main.cpp
+++ b/firmware/tests/pause_and_resume/src/main.cpp
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <pico/stdlib.h>
+#include <dma_double_buffer.h>
+#include <hardware/dma.h>
+#include <hardware/pio.h>
+#include <pio_ltc264x.h>
+#include "f_util.h"
+#include "ff.h"
+#include "hw_config.h"
+
+inline constexpr uint32_t PAUSE_INTERVAL_US = 500000;
+inline constexpr uint32_t WORD_COUNT = 32768;
+
+using T = uint16_t;
+
+#define PICO_PIN (15)
+#define SCK_PIN (16)
+#define CS_PIN (17)
+
+int main() {
+    UINT bytes_read;
+
+    stdio_init_all();
+    while (!stdio_usb_connected()){ sleep_ms(100);} // Wait for user to open com port.
+    printf("Hello, world, from a Raspberry Pi Pico!\r\n");
+
+    // Setup PIO Block for DAC communication.
+    PIO_LTC264x dac(pio2, SCK_PIN, PICO_PIN);
+    dac.start();
+
+    // Setup transfer rate for 500K words-per-sec. Assume soure clock of 150MHz.
+    int dma_timer_chan = dma_claim_unused_timer(true);
+    printf("Claimed DMA Timer %d.\r\n", dma_timer_chan);
+    dma_timer_set_fraction(dma_timer_chan, 1, 30000); // 5 KHz
+    dreq_num_t pacing_signal = dreq_num_t(dma_get_timer_dreq(dma_timer_chan));
+
+    // Create double-buffer. Note: buffer is sized in T-size, not byte size.
+    DMADoubleBuffer<T, WORD_COUNT> buf(pacing_signal, &pio2->txf[dac.get_sm()]);
+
+    // Copy of the current idle buffer name so we can track when it toggles.
+    T* idle_buffer = nullptr;
+    printf("Starting transfer.\r\n");
+    buf.setup_last_dma_transfer(WORD_COUNT); // only do one buffer transfer.
+    buf.start_transfer();
+    uint32_t start_time_s = time_us_32();
+    uint32_t next_time_us = start_time_s + PAUSE_INTERVAL_US;
+    while (true)
+    {
+        while (int32_t(time_us_32() - next_time_us) < 0){}
+        if (buf.transfer_complete())
+            break;
+
+        next_time_us += PAUSE_INTERVAL_US;
+        buf.pause_transfer();
+        printf("Paused transfer.\r\n");
+        if (buf.is_paused())
+            printf("Transfer is now paused.\r\n");
+        else
+            printf("ERROR: Transfer not paused or not detected as paused.\r\n");
+
+        while (int32_t(time_us_32() - next_time_us) < 0){}
+
+        next_time_us += PAUSE_INTERVAL_US;
+        buf.resume_transfer();
+        printf("Resumed transfer.\r\n");
+        if (!buf.is_paused() || buf.transfer_complete())
+            printf("Transfer is now resumed.\r\n");
+        else
+            printf("ERROR: Transfer not resumed or not detected as resumed.\r\n");
+    }
+    printf("Transfer complete! Goodbye, world.\r\n");
+    for (;;);
+}

--- a/firmware/tests/sd_to_dac/src/main.cpp
+++ b/firmware/tests/sd_to_dac/src/main.cpp
@@ -80,7 +80,7 @@ sd_card_t* sd_get_by_num(size_t num) {
 
 int main() {
     // Setup
-    const char* const filename[] = {"channel_0.txt", "channel_1.txt",
+    const char* const filenames[] = {"channel_0.txt", "channel_1.txt",
                                     "channel_2.txt", "channel_3.txt"};
     UINT bytes_read;
 
@@ -94,7 +94,7 @@ int main() {
     printf("Hello, world, from a Raspberry Pi Pico!\r\n");
 
     // Setup PIO Block for DAC communication.
-    std::array<PIO_LTC264x, NUM_FILES> dacs
+    const std::array<PIO_LTC264x, NUM_FILES> dacs
     {{{pio2, SCK_PIN, PICO_PIN},
       {pio2, SCK_PIN1, PICO_PIN1, false, dacs[0].get_offset()},
       {pio2, SCK_PIN2, PICO_PIN2, false, dacs[0].get_offset()},
@@ -137,9 +137,9 @@ int main() {
     // Open 4 files. Note: max number is set by FF_FS_LOCK in ffconf.h
     for (const auto& id: file_ids)
     {
-        fr = f_open(&fil[id], filename[id], FA_READ);
+        fr = f_open(&fil[id], filenames[id], FA_READ);
         if (fr != FR_OK)
-            {panic("Could not open: %s", filename[id]);}
+            {panic("Could not open: %s", filenames[id]);}
     }
     printf("Opened %d file(s).\r\n", NUM_FILES);
     // Read the data in chunks until we reach each file's EOF. Top off the DMA channels.
@@ -160,7 +160,7 @@ int main() {
             // Read the data to the buffer.
             fr = f_read(&fil[id], idle_buffer, SD_CHUNK_SIZE, &bytes_read);
             if (fr != FR_OK)
-                {panic("Could not read the data: %s", filename[id]);}
+                {panic("Could not read the data: %s", filenames[id]);}
 //            printf("Chunk: %d . Read %d bytes.\r\n", chunk_index, bytes_read);
 //            printf("First few uint16s per block: ");
 //            T* buffer_as_T = reinterpret_cast<T*>(idle_buffer);
@@ -197,7 +197,7 @@ int main() {
     {
         fr = f_close(&fil[id]);
         if (fr != FR_OK)
-            {panic("Could not close: %s", filename[id]);}
+            {panic("Could not close: %s", filenames[id]);}
     }
 
     // Unmount.

--- a/firmware/tests/sd_to_dac/src/main.cpp
+++ b/firmware/tests/sd_to_dac/src/main.cpp
@@ -148,7 +148,6 @@ int main() {
     size_t chunk_index = 0;
     while (file_ids.size())
     {
-        //for (auto it = file_ids.begin(); it != file_ids.end(); ++it)
         auto it = file_ids.begin();
         while (it != file_ids.end())
         {


### PR DESCRIPTION
Here's the breakdown:

`DMADoubleBuffer`
* Add Pause/Resume/Abort features
* add/update `is_aborted` and `is_transferring` and fix edge cases

`MultiFilePlayer`
* convert main function to a fully fledged class to handle playback management from multiple files
* interface is abstracted up to: `setup()`, repeated calls to `update()`, and finally `cleanup()`
* support calling `start()` immediately after playback has finished.
* Add example in the tests folder

One way to make heads-or-tails of what's here it to look at the [multi file player test file](https://github.com/AllenNeuralDynamics/harp.device.quad-dac/pull/43/changes#diff-bc076c7c21fb156b329ee387029a90fba1ef061efd4d5c9d4e49bd26d2b18507) to see how the class is used; then have a look at [multi_file_player.h](https://github.com/AllenNeuralDynamics/harp.device.quad-dac/pull/43/changes#diff-fa126f275758c3b17843f1ba6110b0933c245e1eaf5521fae826139e28eea058) and [dma_double_buffer.h](https://github.com/AllenNeuralDynamics/harp.device.quad-dac/pull/43/changes#diff-432f9a45709f694e6ff0da6050f97b259bf9b1e4008a196711f33cb4a675e42b). I marked a few files as unused because they're not really relevant here yet, but it's not worth pulling them from the PR.

Worth mentioning:
* Not yet supported/tested: repeated or infinite loops of playing back the file.
  * This is complicated because we ideally want to read the SD card in multiples of 512 if possible to avoid slowing down the read operation. We will need to check the extra time added when we can't do this at the end/beginning of reading a new file.