### PR TITLE
draft harp interface

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -26,33 +26,51 @@ endif()
 include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
 pico_sdk_init()
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 
 project(quac)
 
 
-add_compile_definitions(USE_PRINTF)
+#add_compile_definitions(USE_PRINTF) # for debuggins sd card lib.
 
 add_subdirectory(lib/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src lib_build/no_os_fatfs_sd_sdio_spi_rpi_pico)
 add_subdirectory(lib/core.pico/firmware lib_build/pico-core)
 add_subdirectory(lib/rp2040.pio-ltc264x lib_build/pio-ltc264x)
+add_subdirectory(lib/etl lib_build/etl)
 
 add_executable(${PROJECT_NAME}
     src/main.cpp
     src/sd_hw_config.cpp
+    src/quac_app.cpp
 )
 
 include_directories(inc)
 
+add_library(dma_double_buffer INTERFACE)
+target_sources(dma_double_buffer INTERFACE
+    inc/dma_double_buffer.h
+)
+
+add_library(multi_file_player INTERFACE)
+target_sources(multi_file_player INTERFACE
+    inc/multi_file_player.h
+)
+
+target_link_libraries(multi_file_player INTERFACE
+    pico_stdlib
+    #hardware_dma
+    pio_ltc264x
+    no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
+    dma_double_buffer
+    etl::etl
+)
 target_link_libraries(${PROJECT_NAME}
-    harp_c_app
-    harp_sync
     pico_stdlib
     pio_ltc264x
+    harp_c_app
+    harp_sync
     #hardware_adc
-    hardware_dma
-    no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
-
+    multi_file_player
 )
 
 pico_add_extra_outputs(${PROJECT_NAME})

--- a/firmware/inc/config.h
+++ b/firmware/inc/config.h
@@ -15,20 +15,25 @@ struct DACPins
 
 using T = uint16_t; // Double Buffer Data Transfer Type.
 
+inline constexpr size_t SHA256_NUM_BYTES = 8;
+
 inline constexpr size_t NUM_CHANNELS = 4;
 inline constexpr std::array<const char*, NUM_CHANNELS> filenames
 {{
     "channel_0.txt", "channel_1.txt", "channel_2.txt", "channel_3.txt"
 }};
+
+inline constexpr size_t WAVEFORM_MAX_WORDS = 5'000'000;
+inline constexpr size_t WAVEFORM_MAX_BYTES = WAVEFORM_MAX_WORDS * sizeof(T);
+
 inline constexpr size_t SD_CHUNK_SIZE_BYTES = 32768; // must be a factor of 512
-inline constexpr size_t BUF_SIZE = SD_CHUNK_SIZE_BYTES/sizeof(T);
+inline constexpr size_t READ_BUF_SIZE = SD_CHUNK_SIZE_BYTES/sizeof(T);
 
 #define DAC_PIO (pio1)
 #define SD_PIO (pio0)
 
 // Double Buffers must be accessible by both cores.
-extern const std::array<PIO_LTC264x, NUM_CHANNELS> dacs;
-extern std::array<DMADoubleBuffer<T, BUF_SIZE>, NUM_CHANNELS> file_bufs;
+extern std::array<PIO_LTC264x, NUM_CHANNELS> dacs;
 
 static_assert(SD_CHUNK_SIZE_BYTES % 512 == 0,
  "SD_CHUNK_SIZE_BYTES must be a multiple of 512 (SD card block size).");
@@ -46,6 +51,11 @@ inline constexpr std::array<DACPins, NUM_CHANNELS> DAC_PINS
 inline constexpr size_t SD_CMD_PIN = 3;
 inline constexpr size_t SD_D0_PIN = 4;
 inline constexpr size_t SD_READ_SPEED_HZ = 150 * 1000 * 1000 / 5; // RP2350: 30 MHz
+
+inline constexpr size_t NUM_DIOS = 4;
+inline constexpr size_t DIO_PORT_BASE = 33;
+inline constexpr uint64_t DIO_PORT_MASK = 0x0000001700000000;
+
 
 
 inline constexpr std::array<uint32_t, NUM_CHANNELS> EXTERNAL_TRIGGERS

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -20,7 +20,7 @@ public:
  * \param filenames
  */
     MultiFilePlayer(std::array<PIO_LTC264x, NUM_CHANNELS>& dacs,
-                    std::array<const char*, NUM_CHANNELS>& filenames)
+                    const std::array<const char*, NUM_CHANNELS>& filenames)
     : dacs_{dacs}, filenames_{filenames}, dma_timer_chan_{-1}
     {
         // Timer setup. Also initializes `timer_pacing_signal_`.
@@ -140,9 +140,11 @@ public:
 /**
  * \brief start one or more channels specified as bitfields.
  * \details multiple channels started this way will be started concurrently.
+ * \note can be called from either core.
  */
     void start(uint32_t channel_mask)
     {
+        // TODO: figure out resume-logic.
         // TODO: maybe make this fn return a bool in case we're not ready (armed)?
         // Create a trigger mask to start all Double Buffer DMA channels at once.
         uint32_t multi_channel_trigger_mask = 0;
@@ -156,6 +158,11 @@ public:
     }
 
     void pause(uint32_t channel_mask)
+    {
+        // TODO.
+    }
+
+    void resume(uint32_t channel_mask)
     {
         // TODO.
     }
@@ -311,7 +318,7 @@ public:
 private:
     // TODO: mark all data structures as __not_in_flash
     std::array<PIO_LTC264x, NUM_CHANNELS>& dacs_;
-    std::array<const char*, NUM_CHANNELS>& filenames_;
+    const std::array<const char*, NUM_CHANNELS>& filenames_;
     std::array<T*, NUM_CHANNELS> idle_buffers_;
     std::array<FIL, NUM_CHANNELS> fils_;
     std::array<FIL*, NUM_CHANNELS> filptrs_;

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -1,0 +1,95 @@
+#ifndef QUAC_H
+#define QUAC_H
+#include <harp_core.h>
+#include <harp_c_app.h>
+#include <waveform_settings.h>
+#include <array>
+#include <config.h>
+#include <multi_file_player.h>
+
+using enum reg_type_t;
+
+inline constexpr size_t APP_REG_COUNT = 22;
+
+#pragma pack(push, 1)
+struct app_regs_t
+{
+    // Digital IO
+    uint8_t dio_port_dir;
+    uint8_t dio_port_state;
+    uint8_t dio_port_set;
+    uint8_t dio_port_clear;
+
+    // Triggers.
+    uint8_t dac_external_triggers;   // Attach Digital Input to trigger DAC
+
+    uint8_t dac_ready;
+    uint8_t dac_start;
+    uint8_t dac_pause; // 1-bit: pause active channel, 0-bit: unpause paused channel
+    uint8_t dac_abort;
+    uint8_t dac_finished;
+
+    WaveformSettings dac_settings[NUM_CHANNELS];
+
+    uint8_t waveform_hashes[NUM_CHANNELS][SHA256_NUM_BYTES];
+    T waveform_data[NUM_CHANNELS]; // treat like a pointer. Data is stored on SD card.
+};
+#pragma pack(pop)
+
+extern MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE> player;
+extern app_regs_t app_regs;
+extern RegSpecs app_reg_specs[APP_REG_COUNT];
+extern RegFnPair reg_handler_fns[APP_REG_COUNT];
+
+
+void read_dio_port_dir(uint8_t address);
+void write_dio_port_dir(msg_t& msg);
+
+/**
+ * \brief read the state of the DIO pins.
+ */
+void read_dio_port_state(uint8_t address);
+void write_dio_port_state(msg_t& msg);
+
+/**
+ * \brief read the last set value.
+ */
+void read_dio_port_set(uint8_t address);
+void write_dio_port_set(msg_t& msg);
+
+/**
+ * \brief read the last set value.
+ */
+void read_dio_port_clear(uint8_t address);
+void write_dio_port_clear(msg_t& msg);
+
+void read_dac_external_triggers(uint8_t address);
+void write_dac_external_triggers(msg_t& msg);
+
+void read_dac_ready(uint8_t address);
+
+void read_dac_start(uint8_t address);
+void write_dac_start(msg_t& msg);
+
+void read_dac_pause(uint8_t address);
+void write_dac_pause(msg_t& msg);
+
+void read_dac_abort(uint8_t address);
+void write_dac_abort(msg_t& msg);
+
+void read_dac_finished(uint8_t address);
+
+void read_any_dac_settings(uint8_t address);
+void write_any_dac_settings(msg_t& msg);
+
+void read_any_waveform_hash(uint8_t address);
+
+void write_any_waveform_data(msg_t& msg);
+
+void reset_app();
+
+void update_app();
+
+
+#endif // QUAC_H
+

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,47 +1,14 @@
 #include <cstring>
 #include <harp_c_app.h>
 #include <harp_synchronizer.h>
-#include <reg_types.h>
 #include <config.h>
+#include <quac_app.h>
 #include <pio_ltc264x.h>
 #ifdef DEBUG
     #include <pico/stdlib.h> // for uart printing
     #include <cstdio> // for printf
 #endif
 
-inline constexpr size_t NUM_APP_REGS = 0;
-
-
-// Define register contents.
-#pragma pack(push, 1)
-struct app_regs_t
-{
-    // TODO
-} app_regs;
-#pragma pack(pop)
-
-
-// Define register "specs."
-RegSpecs app_reg_specs[NUM_APP_REGS]
-{
-    // TODO
-};
-
-// Define register read-and-write handler functions.
-RegFnPair reg_handler_fns[NUM_APP_REGS]
-{
-    // TODO
-};
-
-void app_reset()
-{
-    // TODO
-}
-
-void update_app()
-{
-
-}
 
 // Create Harp App.
 HarpCApp& app = HarpCApp::init(HARP_DEVICE_ID,
@@ -53,8 +20,17 @@ HarpCApp& app = HarpCApp::init(HARP_DEVICE_ID,
                                "quac",
                                (uint8_t*)GIT_HASH,
                                &app_regs, app_reg_specs,
-                               reg_handler_fns, NUM_APP_REGS, update_app,
-                               app_reset);
+                               reg_handler_fns, APP_REG_COUNT, update_app,
+                               reset_app);
+
+std::array<PIO_LTC264x, NUM_CHANNELS> dacs
+{{
+    {pio2, DAC_PINS[0].sck, DAC_PINS[0].pico},
+    {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
+    {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},
+    {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()},
+}};
+MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE> player(dacs, filenames);
 
 // Core0 main.
 int main()
@@ -66,5 +42,9 @@ int main()
     stdio_uart_init_full(uart0, 921600, UART_TX_PIN, -1); // use uart1 tx only.
     printf("Hello, from the quac board!\r\n");
 #endif
-
+    for (const auto& dac: dacs)
+        dac.start();
+    reset_app();
+    while (true)
+        app.run();
 }

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -1,0 +1,232 @@
+#include <quac_app.h>
+
+app_regs_t app_regs;
+
+RegSpecs app_reg_specs[APP_REG_COUNT]
+{
+    {(uint8_t*)&app_regs.dio_port_dir, sizeof(app_regs.dio_port_dir), U8},
+    {(uint8_t*)&app_regs.dio_port_state, sizeof(app_regs.dio_port_state), U8},
+    {(uint8_t*)&app_regs.dio_port_set, sizeof(app_regs.dio_port_set), U8},
+    {(uint8_t*)&app_regs.dio_port_clear, sizeof(app_regs.dio_port_clear), U8},
+
+    {(uint8_t*)&app_regs.dac_external_triggers, sizeof(app_regs.dac_external_triggers), U8},
+
+    {(uint8_t*)&app_regs.dac_ready, sizeof(app_regs.dac_ready), U8},
+    {(uint8_t*)&app_regs.dac_start, sizeof(app_regs.dac_start), U8},
+    {(uint8_t*)&app_regs.dac_pause, sizeof(app_regs.dac_pause), U8},
+    {(uint8_t*)&app_regs.dac_abort, sizeof(app_regs.dac_abort), U8},
+
+    {(uint8_t*)&app_regs.dac_settings[0], sizeof(WaveformSettings), U8},
+    {(uint8_t*)&app_regs.dac_settings[1], sizeof(WaveformSettings), U8},
+    {(uint8_t*)&app_regs.dac_settings[2], sizeof(WaveformSettings), U8},
+    {(uint8_t*)&app_regs.dac_settings[3], sizeof(WaveformSettings), U8},
+
+    {(uint8_t*)&app_regs.waveform_hashes[0], SHA256_NUM_BYTES, U8},
+    {(uint8_t*)&app_regs.waveform_hashes[1], SHA256_NUM_BYTES, U8},
+    {(uint8_t*)&app_regs.waveform_hashes[2], SHA256_NUM_BYTES, U8},
+    {(uint8_t*)&app_regs.waveform_hashes[3], SHA256_NUM_BYTES, U8},
+
+    // Note: WAVEFORM_MAX_BYTES cannot be coerced into RegSpecs type.
+    // num_bytes should be WAVEFORM_MAX_BYTES
+    {(uint8_t*)&app_regs.waveform_hashes[0], 1, U8},
+    {(uint8_t*)&app_regs.waveform_hashes[0], 1, U8},
+    {(uint8_t*)&app_regs.waveform_hashes[0], 1, U8},
+    {(uint8_t*)&app_regs.waveform_hashes[0], 1, U8},
+};
+
+
+RegFnPair reg_handler_fns[APP_REG_COUNT]
+{
+    {read_dio_port_dir, write_dio_port_dir},
+    {read_dio_port_state, write_dio_port_state},
+    {read_dio_port_set, write_dio_port_set},
+    {read_dio_port_clear, write_dio_port_clear},
+
+    {read_dac_external_triggers, write_dac_external_triggers},
+
+    {read_dac_ready, HarpCore::write_to_read_only_reg_error},
+    {read_dac_start, write_dac_start},
+    {read_dac_pause, write_dac_pause},
+    {read_dac_abort, write_dac_abort},
+    {read_dac_finished, HarpCore::write_to_read_only_reg_error},
+
+    {read_any_dac_settings, write_any_dac_settings},
+    {read_any_dac_settings, write_any_dac_settings},
+    {read_any_dac_settings, write_any_dac_settings},
+    {read_any_dac_settings, write_any_dac_settings},
+
+    {read_any_waveform_hash, HarpCore::write_to_read_only_reg_error},
+    {read_any_waveform_hash, HarpCore::write_to_read_only_reg_error},
+    {read_any_waveform_hash, HarpCore::write_to_read_only_reg_error},
+    {read_any_waveform_hash, HarpCore::write_to_read_only_reg_error},
+
+    {HarpCore::read_from_write_only_reg_error, write_any_waveform_data},
+    {HarpCore::read_from_write_only_reg_error, write_any_waveform_data},
+    {HarpCore::read_from_write_only_reg_error, write_any_waveform_data},
+    {HarpCore::read_from_write_only_reg_error, write_any_waveform_data},
+};
+
+
+void read_dio_port_dir(uint8_t address)
+{
+    // Assume we reset to all-inputs.
+    HarpCore::read_reg_generic(address);
+}
+
+
+void write_dio_port_dir(msg_t& msg)
+{
+    HarpCore::copy_msg_payload_to_register(msg);
+    uint64_t dio_mask = uint64_t(app_regs.dio_port_dir) << DIO_PORT_BASE;
+    gpio_set_dir_masked64(dio_mask, dio_mask); // 0-bits: input; 1-bits: output
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void read_dio_port_state(uint8_t address)
+{
+    app_regs.dio_port_state = uint8_t((DIO_PORT_MASK & gpio_get_all64())
+                                      >> DIO_PORT_BASE);
+    HarpCore::read_reg_generic(address);
+}
+
+
+void write_dio_port_state(msg_t& msg)
+{
+    HarpCore::copy_msg_payload_to_register(msg);
+    // Filter out pins specified as inputs.
+    app_regs.dio_port_state = app_regs.dio_port_dir & app_regs.dio_port_state;
+    uint64_t dio_mask = uint64_t(app_regs.dio_port_dir) << DIO_PORT_BASE;
+    uint64_t dio_state_mask = uint64_t(app_regs.dio_port_state) << DIO_PORT_BASE;
+    gpio_put_masked64(dio_mask, dio_state_mask);
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void read_dio_port_set(uint8_t address)
+{HarpCore::read_reg_generic(address);} // should really be a READ ERROR
+
+
+void write_dio_port_set(msg_t& msg)
+{
+    HarpCore::copy_msg_payload_to_register(msg);
+    // Filter out pins specified as inputs.
+    app_regs.dio_port_set = app_regs.dio_port_dir & app_regs.dio_port_set;
+    uint64_t dio_set_mask = uint64_t(app_regs.dio_port_set) << DIO_PORT_BASE;
+    gpio_put_masked64(dio_set_mask, dio_set_mask);
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+void read_dio_port_clear(uint8_t address)
+{HarpCore::read_reg_generic(address);} // should really be a READ ERROR
+
+
+void write_dio_port_clear(msg_t& msg)
+{
+    HarpCore::copy_msg_payload_to_register(msg);
+    // Filter out pins specified as inputs.
+    app_regs.dio_port_clear = app_regs.dio_port_dir & app_regs.dio_port_clear;
+    uint64_t dio_clr_mask = uint64_t(app_regs.dio_port_clear) << DIO_PORT_BASE;
+    gpio_put_masked64(dio_clr_mask, 0);
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void read_dac_external_triggers(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_dac_external_triggers(msg_t& msg)
+{
+    // TODO: implement this.
+}
+
+void read_dac_ready(uint8_t address)
+{
+    // TODO: implement this.
+}
+
+
+void read_dac_start(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_dac_start(msg_t& msg)
+{
+    // TODO: handle paused logic.
+    HarpCore::copy_msg_payload_to_register(msg);
+    player.start(uint32_t(app_regs.dac_start));
+}
+
+
+void read_dac_pause(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_dac_pause(msg_t& msg)
+{
+    // TODO: implement this.
+}
+
+
+void read_dac_abort(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_dac_abort(msg_t& msg)
+{
+    // TODO: implement this.
+}
+
+
+void read_dac_finished(uint8_t address)
+{
+    // TODO: implement this.
+}
+
+
+void read_any_dac_settings(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_any_dac_settings(msg_t& msg)
+{
+    // TODO: implement this.
+}
+
+
+void read_any_waveform_hash(uint8_t address)
+{
+    // TODO: First ensure hash is up-to-date from the card.
+    HarpCore::read_reg_generic(address);
+}
+
+
+void write_any_waveform_data(msg_t& msg)
+{
+    // TODO: will need a custom implementation.
+}
+
+void update_app()
+{
+    // TODO: poll external triggers.
+    // Start any externally triggered DACs if they are armed.
+}
+
+void reset_app()
+{
+    // Reset DIO pins all-inputs.
+    for (size_t i = DIO_PORT_BASE; i < DIO_PORT_BASE + 4; ++i)
+        gpio_init(i);
+    gpio_set_dir_masked64(DIO_PORT_MASK, 0); // 0-bits: input; 1-bits: output
+
+    // TODO: Reset External Triggers to all-inputs.
+
+    // FYI: PIO_LTC264x instances manage GPIO pin function.
+
+    // TODO: reset file player.
+}

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -15,6 +15,7 @@ RegSpecs app_reg_specs[APP_REG_COUNT]
     {(uint8_t*)&app_regs.dac_start, sizeof(app_regs.dac_start), U8},
     {(uint8_t*)&app_regs.dac_pause, sizeof(app_regs.dac_pause), U8},
     {(uint8_t*)&app_regs.dac_abort, sizeof(app_regs.dac_abort), U8},
+    {(uint8_t*)&app_regs.dac_finished, sizeof(app_regs.dac_finished), U8},
 
     {(uint8_t*)&app_regs.dac_settings[0], sizeof(WaveformSettings), U8},
     {(uint8_t*)&app_regs.dac_settings[1], sizeof(WaveformSettings), U8},


### PR DESCRIPTION
Draft the base Harp interface with a set of registers and handler function stubs. These are untested and subject to change; it's mainly meant to help scaffold separate workstreams on different features.

Note that we will also need to merge: https://github.com/harp-tech/core.pico/pull/73 to get the write-only handler function.