### PR TITLE
Feat harp playback

### DIFF
--- a/device.yml
+++ b/device.yml
@@ -98,9 +98,11 @@ registers:
   DACStart:
     address: 42
     type: U8
-    access: Write
+    access: Write, Event
     maskType: AOPort
-    description: ""
+    description: "Write to this register to start any/all ready channels.
+                  Events received from this register represent a bitmask of
+                  channels started via external trigger."
 
   DACAbort:
     address: 43
@@ -185,10 +187,10 @@ bitMasks:
     description: "Available digital IO pins on the device"
     bits:
       None: 0x0
-      DIO0: 0x1
-      DIO1: 0x2
-      DIO2: 0x4
-      DIO3: 0x8
+      DO0: 0x1
+      DO1: 0x2
+      DO2: 0x4
+      DO3: 0x8
   AOPort:
     description: "Available +/-10V analog outputs on the device"
     bits:

--- a/device.yml
+++ b/device.yml
@@ -31,36 +31,93 @@ registers:
     maskType: DIOPort
     description: "Set digital IO specified pins in the mask to logic LOW by setting the corresponding bit."
 
-  DACReady:
+  AnalogOutputPortState:
     address: 36
+    type: U16
+    access: Write
+    length: 4
+    description: "Read/Write the analog output of all 4 AO channels.
+                  Warning: Write values only take effect if all analog output
+                  channels are not busy playing a preset waveform. Write error
+                  otherwise.
+                  Warning: Read values are only valid if all analog output
+                  channels are not busy playing a preset waveform. Read error
+                  otherwise."
+  AnalogOutputChannel0:
+    address: 37
+    type: U16
+    access: Write
+    description: "Read/Set the value of analog output channel 0.
+                  Warning: Write values only take effect if the analog output
+                  channel is not busy playing a preset waveform. Write error
+                  otherwise.
+                  Warning: Read values are only valid if the analog output
+                  channel is not busy playing a preset waveform. Read error
+                  otherwise."
+  AnalogOutputChannel1:
+    address: 38
+    type: U16
+    access: Write
+    description: "Read/Set the value of analog output channel 1.
+                  Warning: Write values only take effect if the analog output
+                  channel is not busy playing a preset waveform. Write error
+                  otherwise.
+                  Warning: Read values are only valid if the analog output
+                  channel is not busy playing a preset waveform. Read error
+                  otherwise."
+  AnalogOutputChannel2:
+    address: 39
+    type: U16
+    access: Write
+    description: "Read/Set the value of analog output channel 2.
+                  Warning: Write values only take effect if the analog output
+                  channel is not busy playing a preset waveform. Write error
+                  otherwise.
+                  Warning: Read values are only valid if the analog output
+                  channel is not busy playing a preset waveform. Read error
+                  otherwise."
+  AnalogOutputChannel3:
+    address: 40
+    type: U16
+    access: Write
+    description: "Read/Set the value of analog output channel 3.
+                  Warning: Write values only take effect if the analog output
+                  channel is not busy playing a preset waveform. Write error
+                  otherwise.
+                  Warning: Read values are only valid if the analog output
+                  channel is not busy playing a preset waveform. Read error
+                  otherwise."
+
+  DACReady:
+    address: 41
     type: U8
     access: Read
     maskType: AOPort
     description: ""
 
   DACStart:
-    address: 37
+    address: 42
     type: U8
     access: Write
     maskType: AOPort
     description: ""
 
   DACAbort:
-    address: 38
+    address: 43
     type: U8
     access: Write
     maskType: AOPort
     description: ""
 
   DACFinished:
-    address: 39
+    address: 44
     type: U8
     access: Event
     maskType: AOPort
     description: ""
 
   WaveformSettings0:
-    address: 40
+    address: 45
     type: U8
     access: Write
     length: 13
@@ -69,7 +126,7 @@ registers:
                   external_triggers (U8)"
 
   WaveformSettings1:
-    address: 41
+    address: 46
     type: U8
     access: Write
     length: 13
@@ -78,7 +135,7 @@ registers:
                   external_triggers (U8)"
 
   WaveformSettings2:
-    address: 42
+    address: 47
     type: U8
     access: Write
     length: 13
@@ -87,7 +144,7 @@ registers:
                   external_triggers (U8)"
 
   WaveformSettings3:
-    address: 43
+    address: 48
     type: U8
     access: Write
     length: 13
@@ -96,28 +153,28 @@ registers:
                   external_triggers (U8)"
 
   WaveformHash0:
-    address: 44
+    address: 49
     type: U8
     access: Read
     length: 8
     description: "Read-only SHA256 hash corresponding to AO0 Waveform."
 
   WaveformHash1:
-    address: 45
+    address: 50
     type: U8
     access: Read
     length: 8
     description: "Read-only SHA256 hash corresponding to AO1 Waveform."
 
   WaveformHash2:
-    address: 46
+    address: 51
     type: U8
     access: Read
     length: 8
     description: "Read-only SHA256 hash corresponding to AO2 Waveform."
 
   WaveformHash3:
-    address: 46
+    address: 52
     type: U8
     access: Read
     length: 8

--- a/device.yml
+++ b/device.yml
@@ -101,23 +101,31 @@ registers:
     description: "Write to this register to start any/all ready channels.
                   Events received from this register represent a bitmask of
                   channels started via external trigger."
+  DACPause:
+    address: 43
+    type: U8
+    access: Write
+    maskType: AOPort
+    description: "Write to this register to pause/resume any/all busy channels.
+                  Writing a 1 pauses the corresponding channel. Writing a 0
+                  resumes the corresponding channel."
 
   DACAbort:
-    address: 43
+    address: 44
     type: U8
     access: Write
     maskType: AOPort
     description: ""
 
   DACFinished:
-    address: 44
+    address: 45
     type: U8
     access: Event
     maskType: AOPort
     description: ""
 
   WaveformSettings0:
-    address: 45
+    address: 46
     type: U8
     access: Write
     length: 13
@@ -126,7 +134,7 @@ registers:
                   external_triggers (U8)"
 
   WaveformSettings1:
-    address: 46
+    address: 47
     type: U8
     access: Write
     length: 13
@@ -135,7 +143,7 @@ registers:
                   external_triggers (U8)"
 
   WaveformSettings2:
-    address: 47
+    address: 48
     type: U8
     access: Write
     length: 13
@@ -144,7 +152,7 @@ registers:
                   external_triggers (U8)"
 
   WaveformSettings3:
-    address: 48
+    address: 49
     type: U8
     access: Write
     length: 13
@@ -153,42 +161,42 @@ registers:
                   external_triggers (U8)"
 
   WaveformHash0:
-    address: 49
+    address: 50
     type: U8
     access: Read
     length: 8
     description: "Read-only SHA256 hash corresponding to AO0 Waveform."
 
   WaveformHash1:
-    address: 50
+    address: 51
     type: U8
     access: Read
     length: 8
     description: "Read-only SHA256 hash corresponding to AO1 Waveform."
 
   WaveformHash2:
-    address: 51
+    address: 52
     type: U8
     access: Read
     length: 8
     description: "Read-only SHA256 hash corresponding to AO2 Waveform."
 
   WaveformHash3:
-    address: 52
+    address: 53
     type: U8
     access: Read
     length: 8
     description: "Read-only SHA256 hash corresponding to AO3 Waveform."
 
   Waveform0:
-    address: 53
+    address: 54
     type: U16
     access: Write
     length: 5000000
     description: "AO0 Waveform."
 
   Waveform1:
-    address: 54
+    address: 55
     type: U16
     access: Write
     length: 5000000

--- a/device.yml
+++ b/device.yml
@@ -6,43 +6,45 @@ whoAmI: 1406
 firmwareVersion: "0.1"
 hardwareTargets: "0.0"
 registers:
-  DIOPortDir:
+  DOPortState:
     address: 32
     type: U8
     access: Write
     maskType: DIOPort
-    description: "Set the direction of the digial IO pins. 0 = input; 1 = output"
-  DIOPortState:
+    description: "Read or write the state of the digital IO pins."
+  DOPortSet:
     address: 33
     type: U8
     access: Write
     maskType: DIOPort
-    description: "Read or write the state of the digital IO pins."
-  DIOPortSet:
+    description: "Set digital IO pins specified in the mask to logic HIGH by setting the corresponding bit."
+  DOPortClear:
     address: 34
     type: U8
     access: Write
     maskType: DIOPort
-    description: "Set digital IO pins specified in the mask to logic HIGH by setting the corresponding bit."
-  DIOPortClear:
+    description: "Set digital IO specified pins in the mask to logic LOW by setting the corresponding bit."
+
+  ExtTriggerState:
     address: 35
     type: U8
-    access: Write
+    access: Read
     maskType: DIOPort
-    description: "Set digital IO specified pins in the mask to logic LOW by setting the corresponding bit."
+    description: "Read the raw state of the external trigger pins."
 
   AnalogOutputPortState:
     address: 36
     type: U16
     access: Write
     length: 4
-    description: "Read/Write the analog output of all 4 AO channels.
+    description: "Read/Write the analog output of all 4 Analog output channels.
                   Warning: Write values only take effect if all analog output
                   channels are not busy playing a preset waveform. Write error
                   otherwise.
                   Warning: Read values are only valid if all analog output
                   channels are not busy playing a preset waveform. Read error
                   otherwise."
+
   AnalogOutputChannel0:
     address: 37
     type: U16
@@ -51,42 +53,38 @@ registers:
                   Warning: Write values only take effect if the analog output
                   channel is not busy playing a preset waveform. Write error
                   otherwise.
-                  Warning: Read values are only valid if the analog output
-                  channel is not busy playing a preset waveform. Read error
-                  otherwise."
+                  Warning: Returns a READ_ERROR if any AO channel is currently
+                  busy playing a preset waveform."
+
   AnalogOutputChannel1:
     address: 38
     type: U16
     access: Write
     description: "Read/Set the value of analog output channel 1.
-                  Warning: Write values only take effect if the analog output
-                  channel is not busy playing a preset waveform. Write error
-                  otherwise.
-                  Warning: Read values are only valid if the analog output
-                  channel is not busy playing a preset waveform. Read error
-                  otherwise."
+                  Warning: Write values only take effect if this channel is not
+                  busy playing a preset waveform. Write error otherwise.
+                  Warning: Returns a READ_ERROR if any AO channel is currently
+                  busy playing a preset waveform."
+
   AnalogOutputChannel2:
     address: 39
     type: U16
     access: Write
     description: "Read/Set the value of analog output channel 2.
-                  Warning: Write values only take effect if the analog output
-                  channel is not busy playing a preset waveform. Write error
-                  otherwise.
-                  Warning: Read values are only valid if the analog output
-                  channel is not busy playing a preset waveform. Read error
-                  otherwise."
+                  Warning: Write values only take effect if this channel is not
+                  busy playing a preset waveform. Write error otherwise.
+                  Warning: Returns a READ_ERROR if any AO channel is currently
+                  busy playing a preset waveform."
+
   AnalogOutputChannel3:
     address: 40
     type: U16
     access: Write
     description: "Read/Set the value of analog output channel 3.
-                  Warning: Write values only take effect if the analog output
-                  channel is not busy playing a preset waveform. Write error
-                  otherwise.
-                  Warning: Read values are only valid if the analog output
-                  channel is not busy playing a preset waveform. Read error
-                  otherwise."
+                  Warning: Write values only take effect if this channel is not
+                  busy playing a preset waveform. Write error otherwise.
+                  Warning: Returns a READ_ERROR if any AO channel is currently
+                  busy playing a preset waveform."
 
   DACReady:
     address: 41
@@ -182,8 +180,36 @@ registers:
     length: 8
     description: "Read-only SHA256 hash corresponding to AO3 Waveform."
 
+  Waveform0:
+    address: 53
+    type: U16
+    access: Write
+    length: 5000000
+    description: "AO0 Waveform."
+
+  Waveform1:
+    address: 54
+    type: U16
+    access: Write
+    length: 5000000
+    description: "AO1 Waveform."
+
+  Waveform2:
+    address: 55
+    type: U16
+    access: Write
+    length: 5000000
+    description: "AO2 Waveform."
+
+  Waveform3:
+    address: 56
+    type: U16
+    access: Write
+    length: 5000000
+    description: "AO3 Waveform."
+
 bitMasks:
-  DIOPort:
+  DOPort:
     description: "Available digital IO pins on the device"
     bits:
       None: 0x0

--- a/device.yml
+++ b/device.yml
@@ -203,14 +203,14 @@ registers:
     description: "AO1 Waveform."
 
   Waveform2:
-    address: 55
+    address: 56
     type: U16
     access: Write
     length: 5000000
     description: "AO2 Waveform."
 
   Waveform3:
-    address: 56
+    address: 57
     type: U16
     access: Write
     length: 5000000

--- a/device.yml
+++ b/device.yml
@@ -218,13 +218,21 @@ registers:
 
 bitMasks:
   DOPort:
-    description: "Available digital IO pins on the device"
+    description: "Available digital output pins on the device"
     bits:
       None: 0x0
       DO0: 0x1
       DO1: 0x2
       DO2: 0x4
       DO3: 0x8
+  DIPort:
+    description: "Available digital input pins on the device"
+    bits:
+      None: 0x0
+      DI0: 0x1
+      DI1: 0x2
+      DI2: 0x4
+      DI3: 0x8
   AOPort:
     description: "Available +/-10V analog outputs on the device"
     bits:

--- a/device.yml
+++ b/device.yml
@@ -1,0 +1,142 @@
+%YAML 1.1
+---
+# yaml-language-server: $schema=https://harp-tech.org/draft-02/schema/device.json
+device: quac
+whoAmI: 1406
+firmwareVersion: "0.1"
+hardwareTargets: "0.0"
+registers:
+  DIOPortDir:
+    address: 32
+    type: U8
+    access: Write
+    maskType: DIOPort
+    description: "Set the direction of the digial IO pins. 0 = input; 1 = output"
+  DIOPortState:
+    address: 33
+    type: U8
+    access: Write
+    maskType: DIOPort
+    description: "Read or write the state of the digital IO pins."
+  DIOPortSet:
+    address: 34
+    type: U8
+    access: Write
+    maskType: DIOPort
+    description: "Set digital IO pins specified in the mask to logic HIGH by setting the corresponding bit."
+  DIOPortClear:
+    address: 35
+    type: U8
+    access: Write
+    maskType: DIOPort
+    description: "Set digital IO specified pins in the mask to logic LOW by setting the corresponding bit."
+
+  DACReady:
+    address: 36
+    type: U8
+    access: Read
+    maskType: AOPort
+    description: ""
+
+  DACStart:
+    address: 37
+    type: U8
+    access: Write
+    maskType: AOPort
+    description: ""
+
+  DACAbort:
+    address: 38
+    type: U8
+    access: Write
+    maskType: AOPort
+    description: ""
+
+  DACFinished:
+    address: 39
+    type: U8
+    access: Event
+    maskType: AOPort
+    description: ""
+
+  WaveformSettings0:
+    address: 40
+    type: U8
+    access: Write
+    length: 13
+    description: "Struct to configure AO0 Waveform settings:
+                  cycles (U32), sample_count (U32), frequency_hz (U32),
+                  external_triggers (U8)"
+
+  WaveformSettings1:
+    address: 41
+    type: U8
+    access: Write
+    length: 13
+    description: "Struct to configure AO1 Waveform settings:
+                  cycles (U32), sample_count (U32), frequency_hz (U32),
+                  external_triggers (U8)"
+
+  WaveformSettings2:
+    address: 42
+    type: U8
+    access: Write
+    length: 13
+    description: "Struct to configure AO2 Waveform settings:
+                  cycles (U32), sample_count (U32), frequency_hz (U32),
+                  external_triggers (U8)"
+
+  WaveformSettings3:
+    address: 43
+    type: U8
+    access: Write
+    length: 13
+    description: "Struct to configure AO3 Waveform settings:
+                  cycles (U32), sample_count (U32), frequency_hz (U32),
+                  external_triggers (U8)"
+
+  WaveformHash0:
+    address: 44
+    type: U8
+    access: Read
+    length: 8
+    description: "Read-only SHA256 hash corresponding to AO0 Waveform."
+
+  WaveformHash1:
+    address: 45
+    type: U8
+    access: Read
+    length: 8
+    description: "Read-only SHA256 hash corresponding to AO1 Waveform."
+
+  WaveformHash2:
+    address: 46
+    type: U8
+    access: Read
+    length: 8
+    description: "Read-only SHA256 hash corresponding to AO2 Waveform."
+
+  WaveformHash3:
+    address: 46
+    type: U8
+    access: Read
+    length: 8
+    description: "Read-only SHA256 hash corresponding to AO3 Waveform."
+
+bitMasks:
+  DIOPort:
+    description: "Available digital IO pins on the device"
+    bits:
+      None: 0x0
+      DIO0: 0x1
+      DIO1: 0x2
+      DIO2: 0x4
+      DIO3: 0x8
+  AOPort:
+    description: "Available +/-10V analog outputs on the device"
+    bits:
+      None: 0x0
+      AO0: 0x1
+      AO1: 0x2
+      AO2: 0x4
+      AO3: 0x8

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(${PROJECT_NAME}
     harp_sync
     #hardware_adc
     multi_file_player
+    pico_multicore
 )
 
 pico_add_extra_outputs(${PROJECT_NAME})

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(${PROJECT_NAME}
     src/main.cpp
     src/sd_hw_config.cpp
     src/quac_app.cpp
+    src/core1_file_player.cpp
 )
 
 include_directories(inc)

--- a/firmware/inc/bitmask_gen.h
+++ b/firmware/inc/bitmask_gen.h
@@ -1,0 +1,18 @@
+#ifndef BITMASK_GEN_H
+#define BITMASK_GEN_H
+#include <limits>
+
+/**
+ * \brief return bitmask at compile-time where \p n specifies the number of
+ * consecutive bits.
+ */
+template <typename T>
+consteval T nwide_mask(size_t n)
+{
+    if (n >= sizeof(T) * 8)
+        return std::numeric_limits<T>::max();
+    return T{(1ull << n) - 1ull};
+}
+
+
+#endif // BITMASK_GEN_H

--- a/firmware/inc/bitmask_gen.h
+++ b/firmware/inc/bitmask_gen.h
@@ -14,5 +14,4 @@ consteval T nwide_mask(size_t n)
     return T{(1ull << n) - 1ull};
 }
 
-
 #endif // BITMASK_GEN_H

--- a/firmware/inc/config.h
+++ b/firmware/inc/config.h
@@ -47,14 +47,20 @@ inline constexpr std::array<DACPins, NUM_CHANNELS> DAC_PINS
     {.pico = 16, .sck = 17, .cs = 18}
 }};
 
+inline constexpr uint16_t DAC_MIDSCALE = 0xFFFF/2;
+
 // SD pins and settings.
 inline constexpr size_t SD_CMD_PIN = 22;
 inline constexpr size_t SD_D0_PIN = 23;
 inline constexpr size_t SD_READ_SPEED_HZ = 150 * 1000 * 1000 / 5; // RP2350: 30 MHz
 
-inline constexpr size_t NUM_DIOS = 4;
-inline constexpr size_t DIO_PORT_BASE = 33;
-inline constexpr uint64_t DIO_PORT_MASK = 0x0000001700000000;
+inline constexpr size_t NUM_DIS = 4;
+inline constexpr size_t DI_PORT_BASE = 29;
+inline constexpr uint64_t DI_PORT_MASK = uint64_t(0b1111) << DI_PORT_BASE;
+
+inline constexpr size_t NUM_DOS = 4;
+inline constexpr size_t DO_PORT_BASE = 33;
+inline constexpr uint64_t DO_PORT_MASK = uint64_t(0b1111) << DO_PORT_BASE;
 
 
 

--- a/firmware/inc/config.h
+++ b/firmware/inc/config.h
@@ -48,8 +48,8 @@ inline constexpr std::array<DACPins, NUM_CHANNELS> DAC_PINS
 }};
 
 // SD pins and settings.
-inline constexpr size_t SD_CMD_PIN = 3;
-inline constexpr size_t SD_D0_PIN = 4;
+inline constexpr size_t SD_CMD_PIN = 22;
+inline constexpr size_t SD_D0_PIN = 23;
 inline constexpr size_t SD_READ_SPEED_HZ = 150 * 1000 * 1000 / 5; // RP2350: 30 MHz
 
 inline constexpr size_t NUM_DIOS = 4;

--- a/firmware/inc/config.h
+++ b/firmware/inc/config.h
@@ -1,10 +1,10 @@
 #ifndef CONFIG_H
 #define CONFIG_H
-
 #include <sd_card.h>  // from no-os* sd card library.
 #include <pio_ltc264x.h>
 #include <dma_double_buffer.h>
 #include <array>
+#include <bitmask_gen.h>
 
 struct DACPins
 {
@@ -54,15 +54,18 @@ inline constexpr size_t SD_READ_SPEED_HZ = 150 * 1000 * 1000 / 5; // RP2350: 30 
 
 inline constexpr size_t NUM_DIS = 4;
 inline constexpr size_t DI_PORT_BASE = 29;
-inline constexpr uint64_t DI_PORT_MASK = uint64_t(0b1111) << DI_PORT_BASE;
+inline constexpr uint64_t DI_PORT_MASK =
+    nwide_mask<uint64_t>(NUM_DIS) << DI_PORT_BASE;
 
 inline constexpr size_t NUM_DOS = 4;
 inline constexpr size_t DO_PORT_BASE = 33;
-inline constexpr uint64_t DO_PORT_MASK = uint64_t(0b1111) << DO_PORT_BASE;
+inline constexpr uint64_t DO_PORT_MASK =
+    nwide_mask<uint64_t>(NUM_DOS) << DO_PORT_BASE;
 
 inline constexpr size_t NUM_EXT_TRIGGERS = 4;
 inline constexpr size_t EXT_TRIGGER_BASE = 29;
-inline constexpr uint64_t EXT_TRIGGER_MASK = uint64_t(0b1111) << EXT_TRIGGER_BASE;
+inline constexpr uint64_t EXT_TRIGGER_MASK =
+    nwide_mask<uint64_t>(NUM_EXT_TRIGGERS) << EXT_TRIGGER_BASE;
 
 
 inline constexpr std::array<uint32_t, NUM_CHANNELS> EXTERNAL_TRIGGERS

--- a/firmware/inc/config.h
+++ b/firmware/inc/config.h
@@ -47,8 +47,6 @@ inline constexpr std::array<DACPins, NUM_CHANNELS> DAC_PINS
     {.pico = 16, .sck = 17, .cs = 18}
 }};
 
-inline constexpr uint16_t DAC_MIDSCALE = 0xFFFF/2;
-
 // SD pins and settings.
 inline constexpr size_t SD_CMD_PIN = 22;
 inline constexpr size_t SD_D0_PIN = 23;
@@ -62,6 +60,9 @@ inline constexpr size_t NUM_DOS = 4;
 inline constexpr size_t DO_PORT_BASE = 33;
 inline constexpr uint64_t DO_PORT_MASK = uint64_t(0b1111) << DO_PORT_BASE;
 
+inline constexpr size_t NUM_EXT_TRIGGERS = 4;
+inline constexpr size_t EXT_TRIGGER_BASE = 29;
+inline constexpr uint64_t EXT_TRIGGER_MASK = uint64_t(0b1111) << EXT_TRIGGER_BASE;
 
 
 inline constexpr std::array<uint32_t, NUM_CHANNELS> EXTERNAL_TRIGGERS

--- a/firmware/inc/config.h
+++ b/firmware/inc/config.h
@@ -20,7 +20,7 @@ inline constexpr size_t SHA256_NUM_BYTES = 8;
 inline constexpr size_t NUM_CHANNELS = 4;
 inline constexpr std::array<const char*, NUM_CHANNELS> filenames
 {{
-    "channel_0.txt", "channel_1.txt", "channel_2.txt", "channel_3.txt"
+    "channel_0.bin", "channel_1.bin", "channel_2.bin", "channel_3.bin"
 }};
 
 inline constexpr size_t WAVEFORM_MAX_WORDS = 5'000'000;
@@ -50,7 +50,7 @@ inline constexpr std::array<DACPins, NUM_CHANNELS> DAC_PINS
 // SD pins and settings.
 inline constexpr size_t SD_CMD_PIN = 22;
 inline constexpr size_t SD_D0_PIN = 23;
-inline constexpr size_t SD_READ_SPEED_HZ = 150 * 1000 * 1000 / 5; // RP2350: 30 MHz
+inline constexpr size_t SD_READ_SPEED_HZ = 150 * 1000 * 1000 / 6; // RP2350: 25 MHz
 
 inline constexpr size_t NUM_DIS = 4;
 inline constexpr size_t DI_PORT_BASE = 29;

--- a/firmware/inc/core1_file_player.h
+++ b/firmware/inc/core1_file_player.h
@@ -1,10 +1,15 @@
 #ifndef CORE1_FILE_PLAYER_H
 #define CORE1_FILE_PLAYER_H
-#include <pico/multicore.h>
+#include <config.h>
 #include <waveform_settings.h>
+#include <multi_file_player.h>
+#include <pico/util/queue.h>
 
-queue_t waveform_settings_queue;
-queue_t bulk_waveform_states_queue;
+//extern queue_t waveform_settings_queue;
+//extern queue_t bulk_waveform_states_queue;
 
+extern MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE> player;
+
+void core1main();
 
 #endif // CORE1_FILE_PLAYER_H

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -146,13 +146,13 @@ public:
         //TODO: uint32_t encoded_transfer_count = dma_encode_transfer_count(word_count);
         dma_channel_hw_addr(data_chan_)->transfer_count = word_count;
         // Attach channel to IRQ if configured to do so:
-         dma_irqn_set_channel_enabled(end_of_transfer_irq_num_, data_chan_,
-                                      trigger_isr_);
-
+        dma_irqn_set_channel_enabled(end_of_transfer_irq_num_, data_chan_,
+                                     trigger_isr_);
         // Disable chaining on the next transfer.
         // Modifying the CTRL register updates settings for the *next* transfer.
         dma_channel_config cfg = dma_get_channel_config(data_chan_);
         channel_config_set_chain_to(&cfg, data_chan_); // chain-to-self disables chaining.
+        channel_config_set_irq_quiet(&cfg, false); // Enable end of transfer irq
         dma_channel_set_config(data_chan_, &cfg, false); // trigger = false
     }
 
@@ -305,6 +305,9 @@ public:
  */
     int get_ctrl_channel() const
     {return ctrl_chan_;}
+
+    int get_data_channel() const
+    {return data_chan_;}
 
 /**
  * \brief get all dma channels used in this class as a single bitmask.

--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -36,7 +36,8 @@ public:
  * (likely a peripheral).
  */
     DMADoubleBuffer(dreq_num_t pacing_signal, volatile void* target_address)
-    :ctrl_chan_{-1}, data_chan_{-1}
+    :ctrl_chan_{-1}, data_chan_{-1},
+     end_of_transfer_irq_num_{-1}, trigger_isr_{false}
     {
         setup_transfer(pacing_signal, target_address);
     }
@@ -108,6 +109,30 @@ public:
     {return *((T**)(dma_channel_hw_addr(ctrl_chan_)->read_addr));}
 
 /**
+ * \brief Enable the last completed dma transfer to trigger an interrupt
+ *  request, i.e: connect DMA channel to IRQ.
+ * \note an interrupt handler function must be attached separately, and the IRQ
+ *  itself must be enabled separately.
+ */
+    void enable_end_of_transfer_irq(uint32_t irq_index)
+    {
+        end_of_transfer_irq_num_ = irq_index;
+        trigger_isr_ = true; // only gets applied in setup_last_dma_transfer()
+    }
+
+/**
+ * \brief Disable the last completed dma transfer to trigger an interrupt.
+ */
+    void disable_end_of_transfer_irq()
+    {
+        trigger_isr_ = false;
+        if (end_of_transfer_irq_num_ < 0) // unspecified. Bail early.
+            return;
+        // Detach it at the hardware level, so the effect is immediate.
+        dma_irqn_set_channel_enabled(end_of_transfer_irq_num_, data_chan_, false);
+    }
+
+/**
  * \brief Exit the Ping-Pong Buffer endless chaining loop by specifying that the
  *  next buffer switch to the buffer that is currently idle will be the last
  *  buffer transfer. Adjust transfer count if we aren't transferring a full
@@ -120,6 +145,9 @@ public:
         // ref: RP2350 pg 1126
         //TODO: uint32_t encoded_transfer_count = dma_encode_transfer_count(word_count);
         dma_channel_hw_addr(data_chan_)->transfer_count = word_count;
+        // Attach channel to IRQ if configured to do so:
+         dma_irqn_set_channel_enabled(end_of_transfer_irq_num_, data_chan_,
+                                      trigger_isr_);
 
         // Disable chaining on the next transfer.
         // Modifying the CTRL register updates settings for the *next* transfer.
@@ -279,6 +307,13 @@ public:
     {return ctrl_chan_;}
 
 /**
+ * \brief get all dma channels used in this class as a single bitmask.
+ */
+    inline uint32_t get_dma_channel_mask() const
+    {return (1u << ctrl_chan_) | (1u << data_chan_);}
+
+
+/**
  * \brief True if neither dma is actively transferring.
  * \note that per-this-implementation, a transfer is considered complete
  *  even if it has been aborted.
@@ -316,6 +351,9 @@ private:
     T (*ctrl_chan_data_[2])[BUF_SIZE];
     int data_chan_;
     dma_channel_config data_chan_default_cfg_;
+
+    int end_of_transfer_irq_num_;
+    bool trigger_isr_;
 };
 #endif // DMA_DOUBLE_BUFFER
 

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -208,21 +208,21 @@ public:
  * \brief true if the channel's buffer has been filled and the underlying
  *  DMA channel can start draining it immediately.
  */
-    inline bool channel_is_armed(size_t channel_index)
+    inline bool channel_is_armed(size_t channel_id)
     {
         //  we can't strictly rely on an nonzero file read pointer
         //  (i.e: `f_tell(fils_[id] != 0`) because the overall file size may be
         //  less than the buffer size, so it would be constantly reset to 0.
-        return (idle_buffers_[channel_index] != nullptr) &&
-               (!file_bufs_[channel_index].is_aborted());
+        return (idle_buffers_[channel_id] != nullptr) &&
+               (!file_bufs_[channel_id].is_aborted());
     }
 
 /**
  * \brief true if channel is transferring data to its respective DAC.
  *  False otherwise (paused or aborted).
  */
-    inline bool channel_is_active(size_t channel_index)
-    {return file_bufs_[channel_index].is_transferring();}
+    inline bool channel_is_active(size_t channel_id)
+    {return file_bufs_[channel_id].is_transferring();}
 
 /**
  * \brief true if any channel needs to be handled with periodic calls to update().
@@ -238,6 +238,16 @@ public:
         }
         return false;
     }
+
+/**
+ * \brief true if the specified channel is ready.
+ */
+    inline bool channel_is_ready(size_t channel_id)
+    {
+        // FIXME: validate that this will be multicore safe.
+        return (!channel_is_active(channel_id)) && channel_is_armed(channel_id);
+    }
+
 
 /**
  * \brief iterate through all channels and update underlying resources.

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -190,7 +190,7 @@ public:
  * \brief static trampoline function to pass to the ISR. ISRs cannot invoke
  *  a pointer-to-member function, so we use this wrapper function instead.
  */
-    static void static_handle_end_of_transfer()
+    static void __not_in_flash_func(static_handle_end_of_transfer)()
     {isr_instance_->handle_end_of_transfer();}
 
 /**
@@ -203,7 +203,7 @@ public:
  * \note implemented as `inline` such that the contents of this function are
  *  (ideally) splatted into the static wrapper function.
  */
-    inline void handle_end_of_transfer()
+    inline void __not_in_flash_func(handle_end_of_transfer)()
     {
         // Do this first.
         for (auto& dac: dacs_)
@@ -481,6 +481,7 @@ private:
 
     int irq_;
 
+    // TODO: annotate as __not_in_flash_func("mfp_static_members")
     static inline MultiFilePlayer<T, NUM_CHANNELS, BUF_SIZE>* isr_instance_ = nullptr;
 
     static inline constexpr size_t SD_CHUNK_SIZE = BUF_SIZE * sizeof(T); // in bytes.

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -6,27 +6,33 @@
 #include <ff.h>
 #include <f_util.h>
 #include <pico/stdlib.h>
+#include <pico/util/queue.h>
 #include <etl/vector.h>
 #include <cmath>
 #include <limits>
 
+/**
+ * \brief represents an event when one or more channels finished transferring
+ *  and when they finished.
+ */
+struct end_of_transfer_event_t
+{
+    uint32_t finished_channels_mask;
+    uint64_t timestamp_us;
+};
 
+
+/**
+ * \brief class for playing multiple files to multiple DACs concurrently.
+ */
 template <typename T, size_t NUM_CHANNELS, size_t BUF_SIZE>
 class MultiFilePlayer
 {
 public:
     static inline constexpr size_t DEFAULT_FREQUENCY_HZ = 500000;
     static inline constexpr T OUTPUT_MIDSCALE = std::numeric_limits<T>::max()/2;
+    static inline constexpr size_t DEFAULT_QUEUE_SIZE = 32;
 
-/**
- * \brief represents an event when one or more channels finished transferring
- *  and when they finished.
- */
-    struct end_of_transfer_event_t
-    {
-        uint32_t finished_channels_mask;
-        uint64_t timestamp_us;
-    };
 
 /**
  * \brief constructor.
@@ -48,6 +54,8 @@ public:
             int32_t sm = dacs_[i].get_sm();
             file_bufs_.emplace_back(timer_pacing_signal_, &pio->txf[sm]);
         }
+        queue_init(&end_of_transfer_event_queue_,
+                   sizeof(end_of_transfer_event_t), DEFAULT_QUEUE_SIZE);
         reset();
     }
 
@@ -84,13 +92,19 @@ public:
         for (auto& dac: dacs_)
             dac.write_value(OUTPUT_MIDSCALE);
         cleanup(); // close all files.
+        // Drain queue.
+        end_of_transfer_event_t dummy_event;
+        while (queue_try_remove(&end_of_transfer_event_queue_, &dummy_event)){}
     }
 
 /**
  * \brief destructor
  */
     ~MultiFilePlayer()
-    {cleanup();}
+    {
+        cleanup();
+        queue_free(&end_of_transfer_event_queue_);
+    }
 
 /**
  * \brief
@@ -131,9 +145,12 @@ public:
  *  Interrupt can be specified explicitly. Otherwise, the default will be used.
  *  For more details on the default interrupt behavior, see
  *  handle_end_of_transfer()
+ * \warning Per current implementation, only one `MultiFilePlayer` instance can
+ *  use the default interrupt handler, because its functionality is tied to a
+ *  static class member.
  */
     void enable_end_of_transfer_interrupt(size_t dma_irq_index,
-                                          void* fn_ptr = nullptr)
+                                          void (*fn_ptr)(void) = nullptr)
     {
         irq_ = DMA_IRQ_0 + dma_irq_index; // get associated IRQ number
         // For the default interrupt callback fn,
@@ -141,11 +158,14 @@ public:
         // pointer-to-function to the IRQ (cannot be pointer-to-member).
         // Connect IRQ to handler function.
         if (fn_ptr == nullptr)
-            fn_ptr = static_handle_end_of_transfer<this>;
+        {
+            fn_ptr = static_handle_end_of_transfer;
+            isr_instance_ = this;
+        }
         irq_set_exclusive_handler(irq_, fn_ptr);
-        // Enable
+        // Enable underlying dma channels to trigger IRQ.
         for (auto& file_buf: file_bufs_)
-            file_buf.enable_end_of_transfer_irq(dma_irq_index);
+            file_buf.enable_end_of_transfer_irq(dma_irq_index); // from 0.
         // Enable the interrupt.
         irq_set_enabled(irq_, true);
     }
@@ -161,19 +181,17 @@ public:
         // Disable the interrupt.
         for (auto& file_buf: file_bufs_)
             file_buf.disable_end_of_transfer_irq();
+        // Enable the interrupt.
+        irq_set_enabled(irq_, false);
         // TODO: clear queue?
     }
 
 /**
  * \brief static trampoline function to pass to the ISR. ISRs cannot invoke
  *  a pointer-to-member function, so we use this wrapper function instead.
- * \note Because the callback function is implemented as static trampoline
-    function using templates, the address of this class instance needs to be
-    known at compile time.
  */
-    template <MultiFilePlayer<T, NUM_CHANNELS, BUF_SIZE>& that>
     static void static_handle_end_of_transfer()
-    {that.handle_end_of_transfer();}
+    {isr_instance_->handle_end_of_transfer();}
 
 /**
  * \brief The ISR callback function to handle the end of any (or multiple)
@@ -183,10 +201,14 @@ public:
  *  - set the corresponding DAC in \ref dacs_ to midscale, i.e: the "idle"
  *    value.
  * \note implemented as `inline` such that the contents of this function are
- *  splatted into the static wrapper function.
+ *  (ideally) splatted into the static wrapper function.
  */
     inline void handle_end_of_transfer()
     {
+        // Do this first.
+        for (auto& dac: dacs_)
+            dac.write_value(OUTPUT_MIDSCALE);
+
         end_of_transfer_event_t end_of_transfer_event;
         end_of_transfer_event.timestamp_us = time_us_64(); // record time asap.
 
@@ -197,23 +219,25 @@ public:
         dma_hw->irq_ctrl[irq_index].ints = int_status;
         // Disconnect already-fired DMA channels from interrupt
         // (since we only fire once at end of buffer transfer).
-        dma_irqn_set_channel_mask_enabled(irq_index, int_status, false);
         // Figure out which DMA channels finished.
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
         {
             if (file_bufs_[i].get_dma_channel_mask() & int_status)
-            {
                 end_of_transfer_event.finished_channels_mask |= 1u << i;
-                dacs_[i].write_value(OUTPUT_MIDSCALE);
-            }
         }
-        // TODO: Push a timestamp bitmask to a queue.
-        //queue_try_add(queue_name, &end_of_transfer_event);
+        // Push a timestamp bitmask to a queue.
+        queue_try_add(&end_of_transfer_event_queue_, &end_of_transfer_event);
     }
 
-    void get_finished_transfers(end_of_transfer_event_t* record)
+/**
+ * \brief receive a record of any finished transfers from a queue and put
+ *  the contents in \p event_ptr.
+ * \return `true`, if a record was successfully remove from the queue;
+ *  `false` otherwise.
+ */
+    inline bool get_finished_transfers(end_of_transfer_event_t* event_ptr)
     {
-        //TODO: queue_try_remove(queue_name, record);
+        return queue_try_remove(&end_of_transfer_event_queue_, event_ptr);
     }
 
 /**
@@ -453,7 +477,11 @@ private:
     int dma_timer_chan_;
     dreq_num_t timer_pacing_signal_;
 
+    queue_t end_of_transfer_event_queue_;
+
     int irq_;
+
+    static inline MultiFilePlayer<T, NUM_CHANNELS, BUF_SIZE>* isr_instance_ = nullptr;
 
     static inline constexpr size_t SD_CHUNK_SIZE = BUF_SIZE * sizeof(T); // in bytes.
 };

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -8,11 +8,14 @@
 #include <pico/stdlib.h>
 #include <etl/vector.h>
 #include <cmath>
+#include <limits>
 
 template <typename T, size_t NUM_CHANNELS, size_t BUF_SIZE>
 class MultiFilePlayer
 {
 public:
+    static inline constexpr size_t DEFAULT_FREQUENCY_HZ = 500000;
+    static inline constexpr T OUTPUT_MIDSCALE = std::numeric_limits<T>::max()/2;
 
 /**
  * \brief constructor.
@@ -231,11 +234,22 @@ public:
     {
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
-            if (channel_is_active(id))
-                return true;
-            else if (!channel_is_armed(id))
+            if (channel_is_busy(id))
                 return true;
         }
+        return false;
+    }
+
+/**
+ * \brief true if the specified channel needs to be handled with periodic calls
+ *  to update().
+ */
+    inline bool channel_is_busy(size_t channel_id)
+    {
+        if (channel_is_active(channel_id))
+            return true;
+        else if (!channel_is_armed(channel_id))
+            return true;
         return false;
     }
 
@@ -340,7 +354,5 @@ private:
     dreq_num_t timer_pacing_signal_;
 
     static inline constexpr size_t SD_CHUNK_SIZE = BUF_SIZE * sizeof(T); // in bytes.
-    static inline constexpr size_t DEFAULT_FREQUENCY_HZ = 500000;
-    static inline constexpr uint16_t OUTPUT_MIDSCALE = 32768;
 };
 #endif // MULTI_FILE_PLAYER_H

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -205,12 +205,9 @@ public:
  */
     inline void __not_in_flash_func(handle_end_of_transfer)()
     {
-        // Do this first.
-        for (auto& dac: dacs_)
-            dac.write_value(OUTPUT_MIDSCALE);
-
         end_of_transfer_event_t end_of_transfer_event;
         end_of_transfer_event.timestamp_us = time_us_64(); // record time asap.
+        end_of_transfer_event.finished_channels_mask = 0;
 
         // Identify which channel(s) triggered the handler.
         uint32_t irq_index = irq_ - DMA_IRQ_0;
@@ -222,8 +219,11 @@ public:
         // Figure out which DMA channels finished.
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
         {
-            if (file_bufs_[i].get_dma_channel_mask() & int_status)
-                end_of_transfer_event.finished_channels_mask |= 1u << i;
+            // Identify which AO channel triggered the interrupt.
+            if (!((1u << file_bufs_[i].get_data_channel()) & int_status))
+                continue; // Skip channels that did not trigger the interrupt.
+            dacs_[i].write_value(OUTPUT_MIDSCALE);
+            end_of_transfer_event.finished_channels_mask |= 1u << i;
         }
         // Push a timestamp bitmask to a queue.
         queue_try_add(&end_of_transfer_event_queue_, &end_of_transfer_event);

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <limits>
 
+
 template <typename T, size_t NUM_CHANNELS, size_t BUF_SIZE>
 class MultiFilePlayer
 {
@@ -24,7 +25,7 @@ public:
  */
     MultiFilePlayer(std::array<PIO_LTC264x, NUM_CHANNELS>& dacs,
                     const std::array<const char*, NUM_CHANNELS>& filenames)
-    : dacs_{dacs}, filenames_{filenames}, dma_timer_chan_{-1}
+    : dacs_{dacs}, filenames_{filenames}, dma_timer_chan_{-1}, irq_{-1}
     {
         // Timer setup. Also initializes `timer_pacing_signal_`.
         dma_timer_chan_ = dma_claim_unused_timer(true);
@@ -37,9 +38,6 @@ public:
             int32_t sm = dacs_[i].get_sm();
             file_bufs_.emplace_back(timer_pacing_signal_, &pio->txf[sm]);
         }
-        std::ranges::fill(filptrs_, nullptr); // mark files as starting closed.
-        std::ranges::fill(curr_iterations_, 0);
-        std::ranges::fill(iterations_, 1);
         reset();
     }
 
@@ -48,19 +46,20 @@ public:
  */
     void setup()
     {
+        // TODO: could use some extra protection to make this func idempotent.
         // Open 4 files. Note: max number is set by FF_FS_LOCK in ffconf.h
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
-            if (file_is_open(id))
-                continue;
-            open_file(id);
+            if (!file_is_open(id))
+                open_file(id);
         }
         // pre-read buffers.
         update();
     }
 
 /**
- * \brief
+ * \brief Reset internal variables and close all files.
+ * \note must call setup() before the class is ready for general usage.
  * \warning not multicore safe.
  */
     void reset()
@@ -68,10 +67,12 @@ public:
         for (size_t i = 0; i < NUM_CHANNELS; ++i)
             file_bufs_[i].abort_transfer(); // Do this first across all channels.
         // TODO: maybe validate that the abort took place?
+        std::ranges::fill(idle_buffers_, nullptr); // Clear local buffer value.
+        std::ranges::fill(filptrs_, nullptr); // mark files as starting closed.
+        std::ranges::fill(curr_iterations_, 0);
+        std::ranges::fill(iterations_, 1);
         for (auto& dac: dacs_)
             dac.write_value(OUTPUT_MIDSCALE);
-        std::ranges::fill(idle_buffers_, nullptr); // Clear local buffer value.
-        std::ranges::fill(curr_iterations_, 0);
         cleanup(); // close all files.
     }
 
@@ -110,10 +111,68 @@ public:
     {
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
-            if (!file_is_open(id))
-                continue;
-            close_file(id);
+            if (file_is_open(id))
+                close_file(id);
         }
+    }
+
+/**
+ * \brief
+ */
+    void enable_record_finished_transfer(size_t irq_index)
+    {
+        // Create a wrapper ("trampoline") function so that we can pass a
+        // pointer-to-function to the IRQ (cannot be pointer-to-member).
+        irq_ = DMA_IRQ_0 + irq_index;
+        // Connect IRQ to handler function.
+        irq_set_exclusive_handler(irq_, static_record_finished_transfer<this>);
+        // Enable
+        for (auto& file_buf: file_bufs_)
+            file_buf.enable_end_of_transfer_irq(irq_index);
+        // Enable the interrupt.
+        irq_set_enabled(irq_, true);
+    }
+
+/**
+ * \brief
+ */
+    void disable_record_finished_transfer()
+    {
+        // Disconnect irq handler function.
+        irq_set_exclusive_handler(irq_, nullptr);
+        irq_ = -1;
+        // Disable the interrupt.
+        for (auto& file_buf: file_bufs_)
+            file_buf.disable_end_of_transfer_irq();
+        // TODO: clear queue?
+    }
+
+/**
+ * \brief static trampoline function to pass to the ISR.
+ * \note Because the callback function is implemented as static trampoline
+    function using templates, the address of this class instance needs to be
+    known at compile time.
+ */
+    template <MultiFilePlayer<T, NUM_CHANNELS, BUF_SIZE>& that>
+    static void static_record_finished_transfer()
+    {that.record_finished_transfer();}
+
+    inline void record_finished_transfer()
+    {
+        // FIXME: do not assume DMA_IRQ_0
+        // Identify which channel(s) triggered the handler.
+        uint32_t irq_index = irq_ - DMA_IRQ_0;
+        uint32_t int_status = dma_hw->irq_ctrl[irq_index].ints;
+        // Clear the interrupt(s).
+        dma_hw->irq_ctrl[irq_index].ints = int_status;
+        // Disconnect already-fired DMA channels from interrupt
+        // (since we only fire once at end of buffer transfer).
+        dma_irqn_set_channel_mask_enabled(irq_index, int_status, false);
+        // Push a timestamp bitmask to a queue.
+        // ...
+        // TODO
+        // ...
+        // TODO: dac.write_value(OUTPUT_MIDSCALE) for finished channels.
     }
 
 /**
@@ -352,6 +411,8 @@ private:
     std::array<WaveformSettings, NUM_CHANNELS> settings_;
     int dma_timer_chan_;
     dreq_num_t timer_pacing_signal_;
+
+    int irq_;
 
     static inline constexpr size_t SD_CHUNK_SIZE = BUF_SIZE * sizeof(T); // in bytes.
 };

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -19,6 +19,16 @@ public:
     static inline constexpr T OUTPUT_MIDSCALE = std::numeric_limits<T>::max()/2;
 
 /**
+ * \brief represents an event when one or more channels finished transferring
+ *  and when they finished.
+ */
+    struct end_of_transfer_event_t
+    {
+        uint32_t finished_channels_mask;
+        uint64_t timestamp_us;
+    };
+
+/**
  * \brief constructor.
  * \param dacs
  * \param filenames
@@ -117,26 +127,33 @@ public:
     }
 
 /**
- * \brief
+ * \brief Enable a finished transfer to trigger an interrupt.
+ *  Interrupt can be specified explicitly. Otherwise, the default will be used.
+ *  For more details on the default interrupt behavior, see
+ *  handle_end_of_transfer()
  */
-    void enable_record_finished_transfer(size_t irq_index)
+    void enable_end_of_transfer_interrupt(size_t dma_irq_index,
+                                          void* fn_ptr = nullptr)
     {
+        irq_ = DMA_IRQ_0 + dma_irq_index; // get associated IRQ number
+        // For the default interrupt callback fn,
         // Create a wrapper ("trampoline") function so that we can pass a
         // pointer-to-function to the IRQ (cannot be pointer-to-member).
-        irq_ = DMA_IRQ_0 + irq_index;
         // Connect IRQ to handler function.
-        irq_set_exclusive_handler(irq_, static_record_finished_transfer<this>);
+        if (fn_ptr == nullptr)
+            fn_ptr = static_handle_end_of_transfer<this>;
+        irq_set_exclusive_handler(irq_, fn_ptr);
         // Enable
         for (auto& file_buf: file_bufs_)
-            file_buf.enable_end_of_transfer_irq(irq_index);
+            file_buf.enable_end_of_transfer_irq(dma_irq_index);
         // Enable the interrupt.
         irq_set_enabled(irq_, true);
     }
 
 /**
- * \brief
+ * \brief 
  */
-    void disable_record_finished_transfer()
+    void disable_end_of_transfer_interrupt()
     {
         // Disconnect irq handler function.
         irq_set_exclusive_handler(irq_, nullptr);
@@ -148,18 +165,31 @@ public:
     }
 
 /**
- * \brief static trampoline function to pass to the ISR.
+ * \brief static trampoline function to pass to the ISR. ISRs cannot invoke
+ *  a pointer-to-member function, so we use this wrapper function instead.
  * \note Because the callback function is implemented as static trampoline
     function using templates, the address of this class instance needs to be
     known at compile time.
  */
     template <MultiFilePlayer<T, NUM_CHANNELS, BUF_SIZE>& that>
-    static void static_record_finished_transfer()
-    {that.record_finished_transfer();}
+    static void static_handle_end_of_transfer()
+    {that.handle_end_of_transfer();}
 
-    inline void record_finished_transfer()
+/**
+ * \brief The ISR callback function to handle the end of any (or multiple)
+ *  file buffer(s) finishing a transfer. Specifically,
+ *  - record which channels finished and when (bitmask, timestamp). Push the
+ *    result to a queue for later collection in a superloop, etc.
+ *  - set the corresponding DAC in \ref dacs_ to midscale, i.e: the "idle"
+ *    value.
+ * \note implemented as `inline` such that the contents of this function are
+ *  splatted into the static wrapper function.
+ */
+    inline void handle_end_of_transfer()
     {
-        // FIXME: do not assume DMA_IRQ_0
+        end_of_transfer_event_t end_of_transfer_event;
+        end_of_transfer_event.timestamp_us = time_us_64(); // record time asap.
+
         // Identify which channel(s) triggered the handler.
         uint32_t irq_index = irq_ - DMA_IRQ_0;
         uint32_t int_status = dma_hw->irq_ctrl[irq_index].ints;
@@ -168,11 +198,22 @@ public:
         // Disconnect already-fired DMA channels from interrupt
         // (since we only fire once at end of buffer transfer).
         dma_irqn_set_channel_mask_enabled(irq_index, int_status, false);
-        // Push a timestamp bitmask to a queue.
-        // ...
-        // TODO
-        // ...
-        // TODO: dac.write_value(OUTPUT_MIDSCALE) for finished channels.
+        // Figure out which DMA channels finished.
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        {
+            if (file_bufs_[i].get_dma_channel_mask() & int_status)
+            {
+                end_of_transfer_event.finished_channels_mask |= 1u << i;
+                dacs_[i].write_value(OUTPUT_MIDSCALE);
+            }
+        }
+        // TODO: Push a timestamp bitmask to a queue.
+        //queue_try_add(queue_name, &end_of_transfer_event);
+    }
+
+    void get_finished_transfers(end_of_transfer_event_t* record)
+    {
+        //TODO: queue_try_remove(queue_name, record);
     }
 
 /**

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -17,6 +17,7 @@ extern queue_t ext_trigger_event_queue;
 inline constexpr size_t APP_REG_COUNT = 26;
 inline constexpr size_t AO_CHANNEL_BASE_ADDRESS = APP_REG_START_ADDRESS + 5;
 inline constexpr size_t DAC_START_ADDRESS = APP_REG_START_ADDRESS + 10;
+inline constexpr size_t DAC_FINSHED_ADDRESS = APP_REG_START_ADDRESS + 13;
 
 
 struct ext_trigger_event_t

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -17,7 +17,6 @@ extern queue_t ext_trigger_event_queue;
 
 
 inline constexpr size_t APP_REG_COUNT = 26;
-inline constexpr size_t AO_CHANNEL_BASE_ADDRESS = APP_REG_START_ADDRESS + 5;
 inline constexpr size_t DAC_START_ADDRESS = APP_REG_START_ADDRESS + 10;
 inline constexpr size_t DAC_FINISHED_ADDRESS = APP_REG_START_ADDRESS + 13;
 

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -17,7 +17,7 @@ extern queue_t ext_trigger_event_queue;
 inline constexpr size_t APP_REG_COUNT = 26;
 inline constexpr size_t AO_CHANNEL_BASE_ADDRESS = APP_REG_START_ADDRESS + 5;
 inline constexpr size_t DAC_START_ADDRESS = APP_REG_START_ADDRESS + 10;
-inline constexpr size_t DAC_FINSHED_ADDRESS = APP_REG_START_ADDRESS + 13;
+inline constexpr size_t DAC_FINISHED_ADDRESS = APP_REG_START_ADDRESS + 13;
 
 
 struct ext_trigger_event_t

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -7,6 +7,8 @@
 #include <config.h>
 #include <multi_file_player.h>
 #include <pico/util/queue.h>
+#include <pico/multicore.h>
+#include <core1_file_player.h>
 
 using enum reg_type_t;
 

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -6,17 +6,24 @@
 #include <array>
 #include <config.h>
 #include <multi_file_player.h>
-#include <pico/multicore.h>
+#include <pico/util/queue.h>
 
 using enum reg_type_t;
 
 extern std::array<PIO_LTC264x, NUM_CHANNELS> dacs;
-queue_t ext_trigger_event_queue;
+extern queue_t ext_trigger_event_queue;
 
 
 inline constexpr size_t APP_REG_COUNT = 26;
 inline constexpr size_t AO_CHANNEL_BASE_ADDRESS = APP_REG_START_ADDRESS + 5;
 inline constexpr size_t DAC_START_ADDRESS = APP_REG_START_ADDRESS + 10;
+
+
+struct ext_trigger_event_t
+{
+    uint32_t channel_start_mask;
+    uint64_t timestamp;
+};
 
 #pragma pack(push, 1)
 struct app_regs_t
@@ -27,7 +34,7 @@ struct app_regs_t
     uint8_t digital_output_port_clear;
 
     // Triggers.
-    uint8_t waveform_triggered;
+    uint8_t ext_trigger_state;
 
     uint16_t analog_output_port_state[NUM_CHANNELS]; // group register view
     uint16_t& analog_output_channel_0 = analog_output_port_state[0];
@@ -54,24 +61,20 @@ extern RegSpecs app_reg_specs[APP_REG_COUNT];
 extern RegFnPair reg_handler_fns[APP_REG_COUNT];
 
 
-void read_digital_output_port_dir(uint8_t address);
-void write_digital_output_port_dir(msg_t& msg);
-
-/**
- * \brief read the state of the DIO pins.
- */
 void read_digital_output_port_state(uint8_t address);
 void write_digital_output_port_state(msg_t& msg);
 
-void write_dio_port_set(msg_t& msg);
+void write_digital_output_port_set(msg_t& msg);
 
-void write_dio_port_clear(msg_t& msg);
+void write_digital_output_port_clear(msg_t& msg);
+
+void read_ext_trigger_state(uint8_t address);
 
 void read_analog_output_port_state(uint8_t address);
 void write_analog_output_port_state(msg_t& msg);
 
-void read_any_ao_channel(uint8_t address);
-void write_any_ao_channel(msg_t& msg);
+void read_any_analog_output_channel(uint8_t address);
+void write_any_analog_output_channel(msg_t& msg);
 
 void read_dac_ready(uint8_t address);
 

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -38,10 +38,10 @@ struct app_regs_t
     uint8_t ext_trigger_state;
 
     uint16_t analog_output_port_state[NUM_CHANNELS]; // group register view
-    uint16_t& analog_output_channel_0 = analog_output_port_state[0];
-    uint16_t& analog_output_channel_1 = analog_output_port_state[1];
-    uint16_t& analog_output_channel_2 = analog_output_port_state[2];
-    uint16_t& analog_output_channel_3 = analog_output_port_state[3];
+    //uint16_t analog_output_channel_0 <- these virtual registers exist.
+    //uint16_t analog_output_channel_1
+    //uint16_t analog_output_channel_2
+    //uint16_t analog_output_channel_3
 
     uint8_t dac_ready;
     uint8_t dac_start;

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -6,13 +6,17 @@
 #include <array>
 #include <config.h>
 #include <multi_file_player.h>
+#include <pico/multicore.h>
 
 using enum reg_type_t;
 
 extern std::array<PIO_LTC264x, NUM_CHANNELS> dacs;
+queue_t ext_trigger_event_queue;
+
 
 inline constexpr size_t APP_REG_COUNT = 26;
-inline constexpr size_t AO_CHANNEL_BASE_ADDRESS = APP_REG_START_ADDRESS;
+inline constexpr size_t AO_CHANNEL_BASE_ADDRESS = APP_REG_START_ADDRESS + 5;
+inline constexpr size_t DAC_START_ADDRESS = APP_REG_START_ADDRESS + 10;
 
 #pragma pack(push, 1)
 struct app_regs_t
@@ -23,7 +27,7 @@ struct app_regs_t
     uint8_t digital_output_port_clear;
 
     // Triggers.
-    uint8_t dac_external_triggers;   // Attach Digital Input to trigger DAC
+    uint8_t waveform_triggered;
 
     uint16_t analog_output_port_state[NUM_CHANNELS]; // group register view
     uint16_t& analog_output_channel_0 = analog_output_port_state[0];
@@ -63,9 +67,6 @@ void write_dio_port_set(msg_t& msg);
 
 void write_dio_port_clear(msg_t& msg);
 
-void read_dac_external_triggers(uint8_t address);
-void write_dac_external_triggers(msg_t& msg);
-
 void read_analog_output_port_state(uint8_t address);
 void write_analog_output_port_state(msg_t& msg);
 
@@ -95,6 +96,11 @@ void write_any_waveform_data(msg_t& msg);
 void reset_app();
 
 void update_app();
+
+
+/// Callbacks
+void handle_external_trigger();
+
 
 
 #endif // QUAC_H

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -9,19 +9,27 @@
 
 using enum reg_type_t;
 
-inline constexpr size_t APP_REG_COUNT = 22;
+extern std::array<PIO_LTC264x, NUM_CHANNELS> dacs;
+
+inline constexpr size_t APP_REG_COUNT = 26;
+inline constexpr size_t AO_CHANNEL_BASE_ADDRESS = APP_REG_START_ADDRESS;
 
 #pragma pack(push, 1)
 struct app_regs_t
 {
-    // Digital IO
-    uint8_t dio_port_dir;
-    uint8_t dio_port_state;
-    uint8_t dio_port_set;
-    uint8_t dio_port_clear;
+    // Digital Output
+    uint8_t digital_output_port_state;
+    uint8_t digital_output_port_set;
+    uint8_t digital_output_port_clear;
 
     // Triggers.
     uint8_t dac_external_triggers;   // Attach Digital Input to trigger DAC
+
+    uint16_t analog_output_port_state[NUM_CHANNELS]; // group register view
+    uint16_t& analog_output_channel_0 = analog_output_port_state[0];
+    uint16_t& analog_output_channel_1 = analog_output_port_state[1];
+    uint16_t& analog_output_channel_2 = analog_output_port_state[2];
+    uint16_t& analog_output_channel_3 = analog_output_port_state[3];
 
     uint8_t dac_ready;
     uint8_t dac_start;
@@ -42,29 +50,27 @@ extern RegSpecs app_reg_specs[APP_REG_COUNT];
 extern RegFnPair reg_handler_fns[APP_REG_COUNT];
 
 
-void read_dio_port_dir(uint8_t address);
-void write_dio_port_dir(msg_t& msg);
+void read_digital_output_port_dir(uint8_t address);
+void write_digital_output_port_dir(msg_t& msg);
 
 /**
  * \brief read the state of the DIO pins.
  */
-void read_dio_port_state(uint8_t address);
-void write_dio_port_state(msg_t& msg);
+void read_digital_output_port_state(uint8_t address);
+void write_digital_output_port_state(msg_t& msg);
 
-/**
- * \brief read the last set value.
- */
-void read_dio_port_set(uint8_t address);
 void write_dio_port_set(msg_t& msg);
 
-/**
- * \brief read the last set value.
- */
-void read_dio_port_clear(uint8_t address);
 void write_dio_port_clear(msg_t& msg);
 
 void read_dac_external_triggers(uint8_t address);
 void write_dac_external_triggers(msg_t& msg);
+
+void read_analog_output_port_state(uint8_t address);
+void write_analog_output_port_state(msg_t& msg);
+
+void read_any_ao_channel(uint8_t address);
+void write_any_ao_channel(msg_t& msg);
 
 void read_dac_ready(uint8_t address);
 

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -93,8 +93,6 @@ void write_dac_pause(msg_t& msg);
 void read_dac_abort(uint8_t address);
 void write_dac_abort(msg_t& msg);
 
-void read_dac_finished(uint8_t address);
-
 void read_any_dac_settings(uint8_t address);
 void write_any_dac_settings(msg_t& msg);
 

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -39,11 +39,11 @@ struct app_regs_t
     // Triggers.
     uint8_t ext_trigger_state;
 
-    uint16_t analog_output_port_state[NUM_CHANNELS]; // group register view
-    //uint16_t analog_output_channel_0 <- these virtual registers exist.
-    //uint16_t analog_output_channel_1
-    //uint16_t analog_output_channel_2
-    //uint16_t analog_output_channel_3
+    uint16_t analog_output_port_state[NUM_CHANNELS];
+    uint16_t& analog_output_channel_0  = analog_output_port_state[0];
+    uint16_t& analog_output_channel_1  = analog_output_port_state[1];
+    uint16_t& analog_output_channel_2  = analog_output_port_state[2];
+    uint16_t& analog_output_channel_3  = analog_output_port_state[3];
 
     uint8_t dac_ready;
     uint8_t dac_start;
@@ -51,9 +51,12 @@ struct app_regs_t
     uint8_t dac_abort;
     uint8_t dac_finished;
 
+    // WaveformSettings are only exposed for read/write as individual registers.
     WaveformSettings dac_settings[NUM_CHANNELS];
 
+    // waveform_hashes are only exposed for read as individual registers.
     uint8_t waveform_hashes[NUM_CHANNELS][SHA256_NUM_BYTES];
+    // waveform_data are only exposed for write as individual registers.
     T waveform_data[NUM_CHANNELS]; // treat like a pointer. Data is stored on SD card.
 };
 #pragma pack(pop)

--- a/firmware/inc/waveform_settings.h
+++ b/firmware/inc/waveform_settings.h
@@ -8,7 +8,7 @@ struct WaveformSettings
     uint32_t cycles; // 0 for loops-forever.
     uint32_t sample_count;
     uint32_t frequency_hz;
-    uint8_t external_triggers;
+    uint8_t external_trigger_mask;
     //uint8_t sha256[8];
 
     // TODO: default constructor should set iterations=1

--- a/firmware/inc/waveform_settings.h
+++ b/firmware/inc/waveform_settings.h
@@ -1,5 +1,6 @@
 #ifndef WAVEFORM_SETTINGS_H
 #define WAVEFORM_SETTINGS_H
+#include <cstdint>
 
 
 #pragma pack(push, 1)

--- a/firmware/inc/waveform_settings.h
+++ b/firmware/inc/waveform_settings.h
@@ -2,9 +2,10 @@
 #define WAVEFORM_SETTINGS_H
 
 
+#pragma pack(push, 1)
 struct WaveformSettings
 {
-    uint32_t iterations; // 0 for loops-forever.
+    uint32_t cycles; // 0 for loops-forever.
     uint32_t sample_count;
     uint32_t frequency_hz;
     uint8_t external_triggers;
@@ -12,6 +13,7 @@ struct WaveformSettings
 
     // TODO: default constructor should set iterations=1
 };
+#pragma pack(pop)
 
 // TODO: should commands be enums, and the actual command is a struct of
 //  {cmd, mask}?

--- a/firmware/src/core1_file_player.cpp
+++ b/firmware/src/core1_file_player.cpp
@@ -2,36 +2,7 @@
 
 void core1main()
 {
-/*
-    WaveformSettings settings;
-    BulkWaveformStates last_bulk_state;
-
-    setup_file_player();
-    BulkWaveformStates last_bulk_state = player.get_bulk_state();
-*/
     // Note: Commands like Pause/Resume/Stop are handled by core0.
     while (true)
-    {
-        // Handle user waveform settings input from core0.
-        //Settings settings;
-/*
-        while (queue_try_remove(&waveform_settings_queue, &bulk_settings)
-        {
-            // apply new settings.
-            // TODO: Can you apply these while the waveform is playing??
-        }
-*/
-        // update file player loop: top off buffers, add/remove files.
         player.update();
-        // TODO: If waveform finished, push finish time to core0.
-        //  Or consider attaching the interrupt on core0??
-
-        //// If the state changes between updates, push it back to core0;
-        //BulkWaveformStates curr_bulk_state = player.get_bulk_state();
-        //if (curr_bulk_state != last_bulk_state)
-        //{
-        //    queue_try_add(&bulk_waveform_states_queue, curr_bulk_state);
-        //    last_bulk_state = curr_bulk_state;
-        //}
-    }
 }

--- a/firmware/src/core1_file_player.cpp
+++ b/firmware/src/core1_file_player.cpp
@@ -2,16 +2,7 @@
 
 void setup_file_player()
 {
-    // Setup DACs. First PIO_LTC264x loads the program; the others share it.
-    const std::array<PIO_LTC264x, NUM_CHANNELS> dacs
-    {{{pio2, DAC_PINS[0].sck, DAC_PINS[0].pico},
-      {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
-      {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},
-      {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()}}};
-    for (const auto& dac: dacs)
-        dac.start();
-
-    MultiFilePlayer player(dacs, filenames);
+    //MultiFilePlayer player(dacs, filenames);
 }
 
 

--- a/firmware/src/core1_file_player.cpp
+++ b/firmware/src/core1_file_player.cpp
@@ -1,30 +1,28 @@
 #include <core1_file_player.h>
 
-void setup_file_player()
+void core1main()
 {
-    //MultiFilePlayer player(dacs, filenames);
-}
-
-
-int core1main()
-{
+/*
     WaveformSettings settings;
     BulkWaveformStates last_bulk_state;
 
     setup_file_player();
     BulkWaveformStates last_bulk_state = player.get_bulk_state();
+*/
     // Note: Commands like Pause/Resume/Stop are handled by core0.
     while (true)
     {
         // Handle user waveform settings input from core0.
         //Settings settings;
+/*
         while (queue_try_remove(&waveform_settings_queue, &bulk_settings)
         {
             // apply new settings.
             // TODO: Can you apply these while the waveform is playing??
         }
+*/
         // update file player loop: top off buffers, add/remove files.
-        update();
+        player.update();
         // TODO: If waveform finished, push finish time to core0.
         //  Or consider attaching the interrupt on core0??
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -43,6 +43,7 @@ int main()
     printf("Hello, from the quac board!\r\n");
 #endif
     queue_init(&ext_trigger_event_queue, sizeof(ext_trigger_event_t), 32);
+    // Setup DACs first.
     for (const auto& dac: dacs)
         dac.start();
     reset_app();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -50,14 +50,8 @@ int main()
 
     // Launch the file player.
     player.enable_end_of_transfer_interrupt(1); // DMA // FIXME: should be on core1
-    player.set_frequency_hz(500'000);
-    player.setup(); // FIXME: Locks up if the files don't exist.
-    // Launch core1.
-/*
-    multicore_reset_core1();
-    (void)multicore_fifo_pop_blocking(); // Wait until core1 is ready.
-    multicore_launch_core1(core1main);
-*/
+    //player.set_frequency_hz(500'000);
+    //player.setup(); // FIXME: Locks up if the files don't exist.
     // Setup DACs first.
     for (const auto& dac: dacs)
         dac.start();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -4,6 +4,7 @@
 #include <config.h>
 #include <quac_app.h>
 #include <pio_ltc264x.h>
+#include <pico/multicore.h>
 #ifdef DEBUG
     #include <pico/stdlib.h> // for uart printing
     #include <cstdio> // for printf
@@ -43,6 +44,20 @@ int main()
     printf("Hello, from the quac board!\r\n");
 #endif
     queue_init(&ext_trigger_event_queue, sizeof(ext_trigger_event_t), 32);
+    // Mount the file system.
+    FATFS fs;
+    FRESULT fr = f_mount(&fs, "", 1);
+
+    // Launch the file player.
+    player.enable_end_of_transfer_interrupt(1); // DMA // FIXME: should be on core1
+    player.set_frequency_hz(500'000);
+    player.setup(); // FIXME: Locks up if the files don't exist.
+    // Launch core1.
+/*
+    multicore_reset_core1();
+    (void)multicore_fifo_pop_blocking(); // Wait until core1 is ready.
+    multicore_launch_core1(core1main);
+*/
     // Setup DACs first.
     for (const auto& dac: dacs)
         dac.start();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -38,10 +38,11 @@ int main()
 // Init Synchronizer.
     HarpSynchronizer::init(uart1, HARP_SYNC_RX_PIN);
     app.set_synchronizer(&HarpSynchronizer::instance());
-    #ifdef DEBUG
+#ifdef DEBUG
     stdio_uart_init_full(uart0, 921600, UART_TX_PIN, -1); // use uart1 tx only.
     printf("Hello, from the quac board!\r\n");
 #endif
+    queue_init(&ext_trigger_event_queue, sizeof(ext_trigger_event_t), 32);
     for (const auto& dac: dacs)
         dac.start();
     reset_app();

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -57,10 +57,10 @@ RegFnPair reg_handler_fns[APP_REG_COUNT]
     {read_any_analog_output_channel, write_any_analog_output_channel},
 
     {read_dac_ready, HarpCore::write_to_read_only_reg_error},
-    {read_dac_start, write_dac_start},
+    {HarpCore::read_from_write_only_reg_error, write_dac_start},
     {read_dac_pause, write_dac_pause},
     {read_dac_abort, write_dac_abort},
-    {read_dac_finished, HarpCore::write_to_read_only_reg_error},
+    {HarpCore::read_from_write_only_reg_error, HarpCore::write_to_read_only_reg_error},
 
     {read_any_dac_settings, write_any_dac_settings},
     {read_any_dac_settings, write_any_dac_settings},
@@ -134,8 +134,6 @@ void read_analog_output_port_state(uint8_t address)
     // Ensure no channels are busy.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (!((app_regs.dac_start >> i) & 1u))
-            continue;
         if (player.channel_is_busy(i))
         {
             HarpCore::send_harp_reply(READ_ERROR, address);
@@ -209,10 +207,6 @@ void read_dac_ready(uint8_t address)
 }
 
 
-void read_dac_start(uint8_t address)
-{HarpCore::read_reg_generic(address);}
-
-
 void write_dac_start(msg_t& msg)
 {
     // TODO: handle paused logic.
@@ -220,15 +214,16 @@ void write_dac_start(msg_t& msg)
     // Ensure specified channels are ready.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (!((app_regs.dac_start >> i) & 1u))
+        if (!((app_regs.dac_start >> i) & 1u)) // Skip untriggered channels.
             continue;
+        // Error if any specified channel is not ready.
         if (!player.channel_is_ready(i))
         {
             HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
             return;
         }
     }
-    player.start(uint32_t(app_regs.dac_start)); // Can be started from core1.
+    player.start(uint32_t(app_regs.dac_start)); // Can be started from core0.
     if (!HarpCore::is_muted())
         HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
@@ -249,12 +244,6 @@ void read_dac_abort(uint8_t address)
 
 
 void write_dac_abort(msg_t& msg)
-{
-    // TODO: implement this.
-}
-
-
-void read_dac_finished(uint8_t address)
 {
     // TODO: implement this.
 }
@@ -318,7 +307,7 @@ void update_app()
         while (player.get_finished_transfers(&transfer_done_event)){}
         return;
     }
-    // Dispatch any transfer-started events.
+    // Dispatch any externally-triggered transfer-started events.
     while (queue_try_remove(&ext_trigger_event_queue, &trigger_event))
     {
         app_regs.dac_start = trigger_event.channel_start_mask;
@@ -387,12 +376,20 @@ void reset_app()
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
         gpio_set_irq_enabled(i + DI_PORT_BASE, GPIO_IRQ_EDGE_RISE, true);
     irq_set_enabled(IO_IRQ_BANK0, true);
+
+    uint32_t LED_MASK = (1u << DEBUG_LEDS[0]) | (1u << DEBUG_LEDS[1]);
+    gpio_init_mask(LED_MASK);
+    gpio_set_dir_masked(LED_MASK, 0xFFFFFFFF); // 1: output.
+    gpio_put_masked(LED_MASK, 0);
 }
 
 // FIXME: this ISR will fire for every rising edge event on said pins--event if
 // all channels are busy.
 void __not_in_flash_func(handle_external_trigger)()
 {
+    uint32_t LED_MASK = (1u << DEBUG_LEDS[0]) | (1u << DEBUG_LEDS[1]);
+    gpio_put_masked(LED_MASK, ~gpio_get_all()); // Toggle LEDs.
+
     // Note: we must read gpios here directly because we are not on a clean
     // multiple of 8-boundary, so it's cumbersome to assemble the interrupt
     // state from multiple reads.

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -374,20 +374,24 @@ void reset_app()
         settings.external_trigger_mask = (1u << i); // DI[i] triggers AO[i].
     }
 
-    // TODO: reset file player.
+    player.reset();
+    player.set_frequency_hz(500'000);
+    player.setup(); // FIXME: Locks up if the files don't exist.
+    // Launch core1.
+    multicore_reset_core1();
+    (void)multicore_fifo_pop_blocking(); // Wait until core1 is ready.
+    multicore_launch_core1(core1main);
 
     // Setup External Trigger Callback
     // Enable all External Trigger GPIOS to trigger the callback.
-    // FIXME: Get this working to launch from files.
-/*
     irq_set_exclusive_handler(IO_IRQ_BANK0, handle_external_trigger);
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
         gpio_set_irq_enabled(i + DI_PORT_BASE, GPIO_IRQ_EDGE_RISE, true);
     irq_set_enabled(IO_IRQ_BANK0, true);
-*/
-    // FIXME: how to reset core1.
 }
 
+// FIXME: this ISR will fire for every rising edge event on said pins--event if
+// all channels are busy.
 void __not_in_flash_func(handle_external_trigger)()
 {
     // Note: we must read gpios here directly because we are not on a clean
@@ -395,23 +399,26 @@ void __not_in_flash_func(handle_external_trigger)()
     // state from multiple reads.
     // Start the waveform per the 1s in the channel.
     // Filter out the busy channels first.
-    uint64_t trigger_mask = ((gpio_get_all64() & DI_PORT_MASK) >> DI_PORT_BASE);
+    uint32_t trigger_mask = ((gpio_get_all64() & DI_PORT_MASK) >> DI_PORT_BASE);
     // Combine waveform settings external triggers to the final mask.
     uint32_t start_mask = 0;
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (player.channel_is_busy(i))
+        if (player.channel_is_busy(i)) // Skip re-triggering busy channels.
             continue;
         // Check if any currently HIGH pins would trigger this channel.
         if (trigger_mask & app_regs.dac_settings[i].external_trigger_mask)
             start_mask |= (1u << i);
     }
-    ext_trigger_event_t trigger_event;
-    player.start(start_mask); // Can be started from core1.
-    trigger_event.channel_start_mask = start_mask;
-    trigger_event.timestamp = time_us_64();
-    // Push harp message
-    queue_try_add(&ext_trigger_event_queue, &trigger_event);
+    if (start_mask != 0)
+    {
+        ext_trigger_event_t trigger_event;
+        player.start(start_mask); // Can be started from core1.
+        trigger_event.channel_start_mask = start_mask;
+        trigger_event.timestamp = time_us_64();
+        // Push harp message
+        queue_try_add(&ext_trigger_event_queue, &trigger_event);
+    }
     // Acknowledge the interrupt. Assume nothing else is setting these pins.
     // Clear the INTR[n] state since we dealt with all pin changes.
     // Clear by "writing a 1" to the set bits.

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -171,8 +171,9 @@ void read_any_analog_output_channel(uint8_t address)
 {
     if (HarpCore::is_muted())
         return;
-    // Convert address to output channel.
-    size_t channel = address - AO_CHANNEL_BASE_ADDRESS;
+    // Convert address to output channel with pointer arithmetic.
+    const RegSpecs& specs = HarpCore::reg_address_to_specs(address);
+    size_t channel = ((uint16_t*)specs.base_ptr - app_regs.analog_output_port_state);
     if (player.channel_is_busy(channel))
     {
         HarpCore::send_harp_reply(READ_ERROR, address);
@@ -185,8 +186,9 @@ void read_any_analog_output_channel(uint8_t address)
 
 void write_any_analog_output_channel(msg_t& msg)
 {
-    // Convert address to output channel.
-    size_t channel = msg.header.address - AO_CHANNEL_BASE_ADDRESS;
+    // Convert address to output channel with pointer arithmetic.
+    const RegSpecs& specs = HarpCore::reg_address_to_specs(msg.header.address);
+    size_t channel = ((uint16_t*)specs.base_ptr - app_regs.analog_output_port_state);
     if (player.channel_is_busy(channel)) // FIXME: launch core1
     {
         if (!HarpCore::is_muted());
@@ -256,8 +258,9 @@ void read_any_dac_settings(uint8_t address)
 void write_any_dac_settings(msg_t& msg)
 {
     // WriteError if we try to change the specified channel while it's busy.
-    // Convert address to output channel.
-    uint32_t channel = msg.header.address - AO_CHANNEL_BASE_ADDRESS;
+    // Convert address to output channel with pointer arithmetic.
+    const RegSpecs& specs = HarpCore::reg_address_to_specs(msg.header.address);
+    size_t channel = ((uint16_t*)specs.base_ptr - app_regs.analog_output_port_state);
     if (player.channel_is_busy(channel))
     {
         HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -301,16 +301,21 @@ void write_any_waveform_data(msg_t& msg)
     irq_set_enabled(IO_IRQ_BANK0, true); // reenable external triggers.
 }
 
+
 void update_app()
 {
-    // TODO: poll external triggers.
-    // Start any externally triggered DACs if they are armed.
+    // FYI: external triggers are handled via interrupts on this core,
+    // But events capturing when they started (or if they errored out)
+    // are collected and dispatched over USB in this loop.
 
     // Send Harp replies for externally-triggered events.
     ext_trigger_event_t trigger_event;
-    if (HarpCore::is_muted()) // Drain the queue and exit.
+    end_of_transfer_event_t transfer_done_event;
+    // Bail early if we're muted. Drain all queues and exit.
+    if (HarpCore::is_muted())
     {
         while (queue_try_remove(&ext_trigger_event_queue, &trigger_event)){}
+        while (player.get_finished_transfers(&transfer_done_event)){}
         return;
     }
     // Dispatch any transfer-started events.
@@ -321,12 +326,11 @@ void update_app()
             HarpCore::system_to_harp_us_64(trigger_event.timestamp));
     }
     // Dispatch any transfer-finished events.
-    end_of_transfer_event_t transfer_done_event;
-    while (player.get_finished_transfers(&event))
+    while (player.get_finished_transfers(&transfer_done_event))
     {
         app_regs.dac_finished = uint8_t(transfer_done_event.finished_channels_mask);
         HarpCore::send_harp_reply(EVENT, DAC_FINISHED_ADDRESS,
-            HarpCore::system_to_harp_us_64(event.timestamp_us));
+            HarpCore::system_to_harp_us_64(transfer_done_event.timestamp_us));
     }
 }
 
@@ -381,11 +385,13 @@ void reset_app()
     irq_set_enabled(IO_IRQ_BANK0, true);
 }
 
-void handle_external_trigger()
+void __not_in_flash_func(handle_external_trigger)()
 {
+    // Note: we must read gpios here directly because we are not on a clean
+    // multiple of 8-boundary, so it's cumbersome to assemble the interrupt
+    // state from multiple reads.
     // Start the waveform per the 1s in the channel.
     // Filter out the busy channels first.
-    // TODO: consider an app_regs.IgnoredTriggers register?
     uint64_t trigger_mask = ((gpio_get_all64() & DI_PORT_MASK) >> DI_PORT_BASE);
     // Combine waveform settings external triggers to the final mask.
     uint32_t start_mask = 0;
@@ -401,6 +407,12 @@ void handle_external_trigger()
     player.start(start_mask); // Can be started from core1.
     trigger_event.channel_start_mask = start_mask;
     trigger_event.timestamp = time_us_64();
-    queue_try_add(&ext_trigger_event_queue, &trigger_event);
     // Push harp message
+    queue_try_add(&ext_trigger_event_queue, &trigger_event);
+    // Acknowledge the interrupt. Assume nothing else is setting these pins.
+    // Clear the INTR[n] state since we dealt with all pin changes.
+    // Clear by "writing a 1" to the set bits.
+    io_bank0_hw->intr[DI_PORT_BASE >> 3] = 0xFFFFFFFF; // >> 3: floor-divide by 8
+    // Do it twice since we are not on a clean multiple of 8 boundary.
+    io_bank0_hw->intr[(DI_PORT_BASE + NUM_CHANNELS) >> 3] = 0xFFFFFFFF;
 }

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -9,7 +9,7 @@ RegSpecs app_reg_specs[APP_REG_COUNT]
     {(uint8_t*)&app_regs.digital_output_port_set, sizeof(app_regs.digital_output_port_set), U8},
     {(uint8_t*)&app_regs.digital_output_port_clear, sizeof(app_regs.digital_output_port_clear), U8},
 
-    {(uint8_t*)&app_regs.dac_external_triggers, sizeof(app_regs.dac_external_triggers), U8},
+    {(uint8_t*)&app_regs.ext_trigger_state, sizeof(app_regs.ext_trigger_state), U8},
 
     {(uint8_t*)&app_regs.analog_output_port_state, sizeof(app_regs.analog_output_port_state), U16},
     {(uint8_t*)&app_regs.analog_output_channel_0, sizeof(app_regs.analog_output_channel_0), U16},
@@ -48,13 +48,13 @@ RegFnPair reg_handler_fns[APP_REG_COUNT]
     {HarpCore::read_from_write_only_reg_error, write_digital_output_port_set},
     {HarpCore::read_from_write_only_reg_error, write_digital_output_port_clear},
 
-    {read_dac_external_triggers, write_dac_external_triggers},
+    {read_ext_trigger_state, HarpCore::write_to_read_only_reg_error},
 
-    {read_analog_output_port_state; write_analog_output_port_state},
-    {read_any_analog_output_channel; write_any_analog_output_channel},
-    {read_any_analog_output_channel; write_any_analog_output_channel},
-    {read_any_analog_output_channel; write_any_analog_output_channel},
-    {read_any_analog_output_channel; write_any_analog_output_channel},
+    {read_analog_output_port_state, write_analog_output_port_state},
+    {read_any_analog_output_channel, write_any_analog_output_channel},
+    {read_any_analog_output_channel, write_any_analog_output_channel},
+    {read_any_analog_output_channel, write_any_analog_output_channel},
+    {read_any_analog_output_channel, write_any_analog_output_channel},
 
     {read_dac_ready, HarpCore::write_to_read_only_reg_error},
     {read_dac_start, write_dac_start},
@@ -81,8 +81,8 @@ RegFnPair reg_handler_fns[APP_REG_COUNT]
 
 void read_digital_output_port_state(uint8_t address)
 {
-    app_regs.digital_output_port_state = uint8_t((DO_PORT_MASK & gpio_get_all64())
-                                      >> DO_PORT_BASE);
+    app_regs.digital_output_port_state =
+        uint8_t((DO_PORT_MASK & gpio_get_all64()) >> DO_PORT_BASE);
     HarpCore::read_reg_generic(address);
 }
 
@@ -90,11 +90,9 @@ void read_digital_output_port_state(uint8_t address)
 void write_digital_output_port_state(msg_t& msg)
 {
     HarpCore::copy_msg_payload_to_register(msg);
-    // Filter out pins specified as inputs.
-    app_regs.digital_output_port_state = app_regs.digital_output_port_dir & app_regs.digital_output_port_state;
-    uint64_t digital_output_mask = uint64_t(app_regs.digital_output_port_dir) << DO_PORT_BASE;
-    uint64_t digital_output_state_mask = uint64_t(app_regs.digital_output_port_state) << DO_PORT_BASE;
-    gpio_put_masked64(digital_output_mask, digital_output_state_mask);
+    uint64_t digital_output_state_mask =
+        uint64_t(app_regs.digital_output_port_state) << DO_PORT_BASE;
+    gpio_put_masked64(DO_PORT_MASK, digital_output_state_mask);
     if (!HarpCore::is_muted())
         HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
@@ -103,9 +101,8 @@ void write_digital_output_port_state(msg_t& msg)
 void write_digital_output_port_set(msg_t& msg)
 {
     HarpCore::copy_msg_payload_to_register(msg);
-    // Filter out pins specified as inputs.
-    app_regs.digital_output_port_set = app_regs.digital_output_port_dir & app_regs.digital_output_port_set;
-    uint64_t digital_output_set_mask = uint64_t(app_regs.digital_output_port_set) << DO_PORT_BASE;
+    uint64_t digital_output_set_mask =
+        uint64_t(app_regs.digital_output_port_set) << DO_PORT_BASE;
     gpio_put_masked64(digital_output_set_mask, digital_output_set_mask);
     if (!HarpCore::is_muted())
         HarpCore::send_harp_reply(WRITE, msg.header.address);
@@ -115,8 +112,6 @@ void write_digital_output_port_set(msg_t& msg)
 void write_digital_output_port_clear(msg_t& msg)
 {
     HarpCore::copy_msg_payload_to_register(msg);
-    // Filter out pins specified as inputs.
-    app_regs.digital_output_port_clear = app_regs.digital_output_port_dir & app_regs.digital_output_port_clear;
     uint64_t digital_output_clr_mask = uint64_t(app_regs.digital_output_port_clear) << DO_PORT_BASE;
     gpio_put_masked64(digital_output_clr_mask, 0);
     if (!HarpCore::is_muted())
@@ -124,13 +119,11 @@ void write_digital_output_port_clear(msg_t& msg)
 }
 
 
-void read_dac_external_triggers(uint8_t address)
-{HarpCore::read_reg_generic(address);}
-
-
-void write_dac_external_triggers(msg_t& msg)
+void read_ext_trigger_state(uint8_t address)
 {
-    // TODO: implement this.
+    app_regs.ext_trigger_state =
+        uint8_t((EXT_TRIGGER_MASK & gpio_get_all64()) >> EXT_TRIGGER_BASE);
+    HarpCore::read_reg_generic(address);
 }
 
 
@@ -145,14 +138,14 @@ void read_analog_output_port_state(uint8_t address)
             continue;
         if (player.channel_is_busy(i))
         {
-            HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+            HarpCore::send_harp_reply(READ_ERROR, address);
             return;
         }
     }
     // Update register contents.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
         app_regs.analog_output_port_state[i] = dacs[i].get_last_value();
-    HarpCore::send_harp_reply(WRITE, msg.header.address);
+    HarpCore::send_harp_reply(READ, address);
 }
 
 
@@ -188,6 +181,7 @@ void read_any_analog_output_channel(uint8_t address)
         return;
     }
     app_regs.analog_output_port_state[channel] = dacs[channel].get_last_value();
+    HarpCore::send_harp_reply(READ, address);
 }
 
 
@@ -198,14 +192,14 @@ void write_any_analog_output_channel(msg_t& msg)
     if (player.channel_is_busy(channel))
     {
         if (!HarpCore::is_muted());
-            HarCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+            HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
         return;
     }
     HarpCore::copy_msg_payload_to_register(msg);
     // FYI: also updates the individual register representation bc it's a ref.
     dacs[channel].write_value(app_regs.analog_output_port_state[channel]);
     if (!HarpCore::is_muted())
-        HarCore::send_harp_reply(WRITE, address);
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
 
 
@@ -274,18 +268,18 @@ void write_any_dac_settings(msg_t& msg)
 {
     // WriteError if we try to change the specified channel while it's busy.
     // Convert address to output channel.
-    uint32_t channel = address - AO_CHANNEL_BASE_ADDRESS;
-    if (player.channel_is_busy(channel)
+    uint32_t channel = msg.header.address - AO_CHANNEL_BASE_ADDRESS;
+    if (player.channel_is_busy(channel))
     {
         HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
         return;
     }
-    HarpCore::copy_msg_payload_to_register();
+    HarpCore::copy_msg_payload_to_register(msg);
     // TODO: Send waveform settings to core1.
     // ...
     // ...
     if (!HarpCore::is_muted())
-        HarpCore::send_harp_reply(msg.header.address);
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
 
 
@@ -321,9 +315,9 @@ void update_app()
     }
     while (queue_try_remove(&ext_trigger_event_queue, &trigger_event))
     {
-        app_regs.dac_start = trigger_event.start_mask;
+        app_regs.dac_start = trigger_event.channel_start_mask;
         HarpCore::send_harp_reply(EVENT, DAC_START_ADDRESS,
-                                  system_to_harp_us_64(trigger_event.timestamp));
+            HarpCore::system_to_harp_us_64(trigger_event.timestamp));
     }
 }
 
@@ -339,7 +333,7 @@ void reset_app()
 
     // Reset Digital Outputs.
     gpio_set_dir_masked64(DO_PORT_MASK, DO_PORT_MASK); // 1-bit: output.
-    gpio_set_put_masked64(digital_output_mask, 0); // Set all outputs LOW.
+    gpio_put_masked64(DO_PORT_MASK, 0); // Set all outputs LOW.
 
     memset(&app_regs.waveform_hashes[0], 0, SHA256_NUM_BYTES);
     memset(&app_regs.waveform_hashes[1], 0, SHA256_NUM_BYTES);
@@ -348,17 +342,22 @@ void reset_app()
     // TODO: open SD card, find hash files, update Harp reg hashes as needed.
 
     // FYI: PIO_LTC264x instances manage GPIO pin function.
-    for (const auto& dac: dacs)
-        dacs.write_value(DAC_MIDSCALE);
+    const T& DAC_MIDSCALE =
+        MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE>::OUTPUT_MIDSCALE;
+    const size_t DEFAULT_FREQUENCY_HZ =
+        MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE>::DEFAULT_FREQUENCY_HZ;
+
+    for (auto& dac: dacs)
+        dac.write_value(DAC_MIDSCALE);
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
         app_regs.analog_output_port_state[i] = DAC_MIDSCALE;
     // Reset Waveform trigger settings.
-    for (size_t i = 0; I < NUM_CHANNELS)
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        auto& settings = dac_settings[i];
+        auto& settings = app_regs.dac_settings[i];
         settings.cycles = 1; // play once: "single-shot."
         settings.sample_count = 0; // Play everything.
-        settings.frequency_hz = MultiFilePlayer::DEFAULT_FREQUENCY_HZ; // 500KHz
+        settings.frequency_hz = DEFAULT_FREQUENCY_HZ;
         settings.external_trigger_mask = (1u << i); // DI[i] triggers AO[i].
     }
 
@@ -378,9 +377,9 @@ void handle_external_trigger()
     // Start the waveform per the 1s in the channel.
     // Filter out the busy channels first.
     // TODO: consider an app_regs.IgnoredTriggers register?
-    uint32_t trigger_mask = ((gpio_get_all64() & DI_PORT_MASK) >> DI_PORT_BASE);
+    uint64_t trigger_mask = ((gpio_get_all64() & DI_PORT_MASK) >> DI_PORT_BASE);
     // Combine waveform settings external triggers to the final mask.
-    start_mask = 0;
+    uint32_t start_mask = 0;
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
         if (player.channel_is_busy(i))
@@ -389,10 +388,9 @@ void handle_external_trigger()
         if (trigger_mask & app_regs.dac_settings[i].external_trigger_mask)
             start_mask |= (1u << i);
     }
-    start_mask &= composite_mask;
     ext_trigger_event_t trigger_event;
     player.start(start_mask); // Can be started from core1.
-    trigger_event.channel_mask = start_mask;
+    trigger_event.channel_start_mask = start_mask;
     trigger_event.timestamp = time_us_64();
     queue_try_add(&ext_trigger_event_queue, &trigger_event);
     // Push harp message

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -160,7 +160,20 @@ void write_dac_start(msg_t& msg)
 {
     // TODO: handle paused logic.
     HarpCore::copy_msg_payload_to_register(msg);
-    player.start(uint32_t(app_regs.dac_start));
+    // Ensure specified channels are ready.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    {
+        if (!((app_regs.dac_start >> i) & 1u))
+            continue;
+        if (!player.channel_is_ready(i))
+        {
+            HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+            return;
+        }
+    }
+    player.start(uint32_t(app_regs.dac_start)); // Can be started from core1.
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
 
 

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -352,6 +352,15 @@ void reset_app()
         dacs.write_value(DAC_MIDSCALE);
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
         app_regs.analog_output_port_state[i] = DAC_MIDSCALE;
+    // Reset Waveform trigger settings.
+    for (size_t i = 0; I < NUM_CHANNELS)
+    {
+        auto& settings = dac_settings[i];
+        settings.cycles = 1; // play once: "single-shot."
+        settings.sample_count = 0; // Play everything.
+        settings.frequency_hz = MultiFilePlayer::DEFAULT_FREQUENCY_HZ; // 500KHz
+        settings.external_trigger_mask = (1u << i); // DI[i] triggers AO[i].
+    }
 
     // TODO: reset file player.
 

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -4,12 +4,17 @@ app_regs_t app_regs;
 
 RegSpecs app_reg_specs[APP_REG_COUNT]
 {
-    {(uint8_t*)&app_regs.dio_port_dir, sizeof(app_regs.dio_port_dir), U8},
-    {(uint8_t*)&app_regs.dio_port_state, sizeof(app_regs.dio_port_state), U8},
-    {(uint8_t*)&app_regs.dio_port_set, sizeof(app_regs.dio_port_set), U8},
-    {(uint8_t*)&app_regs.dio_port_clear, sizeof(app_regs.dio_port_clear), U8},
+    {(uint8_t*)&app_regs.digital_output_port_state, sizeof(app_regs.digital_output_port_state), U8},
+    {(uint8_t*)&app_regs.digital_output_port_set, sizeof(app_regs.digital_output_port_set), U8},
+    {(uint8_t*)&app_regs.digital_output_port_clear, sizeof(app_regs.digital_output_port_clear), U8},
 
     {(uint8_t*)&app_regs.dac_external_triggers, sizeof(app_regs.dac_external_triggers), U8},
+
+    {(uint8_t*)&app_regs.analog_output_port_state, sizeof(app_regs.analog_output_port_state), U16},
+    {(uint8_t*)&app_regs.analog_output_channel_0, sizeof(app_regs.analog_output_channel_0), U16},
+    {(uint8_t*)&app_regs.analog_output_channel_1, sizeof(app_regs.analog_output_channel_1), U16},
+    {(uint8_t*)&app_regs.analog_output_channel_2, sizeof(app_regs.analog_output_channel_2), U16},
+    {(uint8_t*)&app_regs.analog_output_channel_3, sizeof(app_regs.analog_output_channel_3), U16},
 
     {(uint8_t*)&app_regs.dac_ready, sizeof(app_regs.dac_ready), U8},
     {(uint8_t*)&app_regs.dac_start, sizeof(app_regs.dac_start), U8},
@@ -38,12 +43,17 @@ RegSpecs app_reg_specs[APP_REG_COUNT]
 
 RegFnPair reg_handler_fns[APP_REG_COUNT]
 {
-    {read_dio_port_dir, write_dio_port_dir},
-    {read_dio_port_state, write_dio_port_state},
-    {read_dio_port_set, write_dio_port_set},
-    {read_dio_port_clear, write_dio_port_clear},
+    {read_digital_output_port_state, write_digital_output_port_state},
+    {HarpCore::read_from_write_only_reg_error, write_digital_output_port_set},
+    {HarpCore::read_from_write_only_reg_error, write_digital_output_port_clear},
 
     {read_dac_external_triggers, write_dac_external_triggers},
+
+    {read_analog_output_port_state; write_analog_output_port_state},
+    {read_any_analog_output_channel; write_any_analog_output_channel},
+    {read_any_analog_output_channel; write_any_analog_output_channel},
+    {read_any_analog_output_channel; write_any_analog_output_channel},
+    {read_any_analog_output_channel; write_any_analog_output_channel},
 
     {read_dac_ready, HarpCore::write_to_read_only_reg_error},
     {read_dac_start, write_dac_start},
@@ -68,70 +78,46 @@ RegFnPair reg_handler_fns[APP_REG_COUNT]
 };
 
 
-void read_dio_port_dir(uint8_t address)
+void read_digital_output_port_state(uint8_t address)
 {
-    // Assume we reset to all-inputs.
+    app_regs.digital_output_port_state = uint8_t((DO_PORT_MASK & gpio_get_all64())
+                                      >> DO_PORT_BASE);
     HarpCore::read_reg_generic(address);
 }
 
 
-void write_dio_port_dir(msg_t& msg)
+void write_digital_output_port_state(msg_t& msg)
 {
     HarpCore::copy_msg_payload_to_register(msg);
-    uint64_t dio_mask = uint64_t(app_regs.dio_port_dir) << DIO_PORT_BASE;
-    gpio_set_dir_masked64(dio_mask, dio_mask); // 0-bits: input; 1-bits: output
+    // Filter out pins specified as inputs.
+    app_regs.digital_output_port_state = app_regs.digital_output_port_dir & app_regs.digital_output_port_state;
+    uint64_t digital_output_mask = uint64_t(app_regs.digital_output_port_dir) << DO_PORT_BASE;
+    uint64_t digital_output_state_mask = uint64_t(app_regs.digital_output_port_state) << DO_PORT_BASE;
+    gpio_put_masked64(digital_output_mask, digital_output_state_mask);
     if (!HarpCore::is_muted())
         HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
 
 
-void read_dio_port_state(uint8_t address)
-{
-    app_regs.dio_port_state = uint8_t((DIO_PORT_MASK & gpio_get_all64())
-                                      >> DIO_PORT_BASE);
-    HarpCore::read_reg_generic(address);
-}
-
-
-void write_dio_port_state(msg_t& msg)
+void write_digital_output_port_set(msg_t& msg)
 {
     HarpCore::copy_msg_payload_to_register(msg);
     // Filter out pins specified as inputs.
-    app_regs.dio_port_state = app_regs.dio_port_dir & app_regs.dio_port_state;
-    uint64_t dio_mask = uint64_t(app_regs.dio_port_dir) << DIO_PORT_BASE;
-    uint64_t dio_state_mask = uint64_t(app_regs.dio_port_state) << DIO_PORT_BASE;
-    gpio_put_masked64(dio_mask, dio_state_mask);
+    app_regs.digital_output_port_set = app_regs.digital_output_port_dir & app_regs.digital_output_port_set;
+    uint64_t digital_output_set_mask = uint64_t(app_regs.digital_output_port_set) << DO_PORT_BASE;
+    gpio_put_masked64(digital_output_set_mask, digital_output_set_mask);
     if (!HarpCore::is_muted())
         HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
 
 
-void read_dio_port_set(uint8_t address)
-{HarpCore::read_reg_generic(address);} // should really be a READ ERROR
-
-
-void write_dio_port_set(msg_t& msg)
+void write_digital_output_port_clear(msg_t& msg)
 {
     HarpCore::copy_msg_payload_to_register(msg);
     // Filter out pins specified as inputs.
-    app_regs.dio_port_set = app_regs.dio_port_dir & app_regs.dio_port_set;
-    uint64_t dio_set_mask = uint64_t(app_regs.dio_port_set) << DIO_PORT_BASE;
-    gpio_put_masked64(dio_set_mask, dio_set_mask);
-    if (!HarpCore::is_muted())
-        HarpCore::send_harp_reply(WRITE, msg.header.address);
-}
-
-void read_dio_port_clear(uint8_t address)
-{HarpCore::read_reg_generic(address);} // should really be a READ ERROR
-
-
-void write_dio_port_clear(msg_t& msg)
-{
-    HarpCore::copy_msg_payload_to_register(msg);
-    // Filter out pins specified as inputs.
-    app_regs.dio_port_clear = app_regs.dio_port_dir & app_regs.dio_port_clear;
-    uint64_t dio_clr_mask = uint64_t(app_regs.dio_port_clear) << DIO_PORT_BASE;
-    gpio_put_masked64(dio_clr_mask, 0);
+    app_regs.digital_output_port_clear = app_regs.digital_output_port_dir & app_regs.digital_output_port_clear;
+    uint64_t digital_output_clr_mask = uint64_t(app_regs.digital_output_port_clear) << DO_PORT_BASE;
+    gpio_put_masked64(digital_output_clr_mask, 0);
     if (!HarpCore::is_muted())
         HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
@@ -145,6 +131,66 @@ void write_dac_external_triggers(msg_t& msg)
 {
     // TODO: implement this.
 }
+
+
+void read_analog_output_port_state(uint8_t address)
+{
+    // TODO
+}
+
+
+void write_analog_output_port_state(msg_t& msg)
+{
+    // Ensure no channels are busy.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    {
+        if (!((app_regs.dac_start >> i) & 1u))
+            continue;
+        if (!player.channel_is_ready(i))
+        {
+            HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+            return;
+        }
+    }
+    // Apply the write.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        dacs[i].write_value(app_regs.analog_output_port_state[i]);
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void read_any_analog_output_channel(uint8_t address)
+{
+    // Convert address to output channel.
+    uint32_t channel = address - AO_CHANNEL_BASE_ADDRESS;
+    if (player.channel_is_busy(channel))
+    {
+        HarCore::send_harp_reply(READ_ERROR, address);
+        return;
+    }
+    app_regs.analog_output_port_state[channel] = dacs[channel].get_last_value();
+    if (!HarpCore::is_muted())
+        HarCore::send_harp_reply(READ, address);
+}
+
+
+void write_any_analog_output_channel(msg_t& msg)
+{
+    // Convert address to output channel.
+    uint32_t channel = msg.header.address - AO_CHANNEL_BASE_ADDRESS;
+    if (player.channel_is_busy(channel))
+    {
+        HarCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+        return;
+    }
+    HarpCore::copy_msg_payload_to_register(msg);
+    // FYI: also updates the individual register representation bc it's a ref.
+    dacs[channel].write_value(app_regs.analog_output_port_state[channel]);
+    if (!HarpCore::is_muted())
+        HarCore::send_harp_reply(WRITE, address);
+}
+
 
 void read_dac_ready(uint8_t address)
 {
@@ -215,7 +261,8 @@ void write_any_dac_settings(msg_t& msg)
 
 void read_any_waveform_hash(uint8_t address)
 {
-    // TODO: First ensure hash is up-to-date from the card.
+    // Assumes we have connected to the SD card on reset and keep this hash
+    // updated each time we write a new waveform to the card via Harp interface.
     HarpCore::read_reg_generic(address);
 }
 
@@ -233,14 +280,29 @@ void update_app()
 
 void reset_app()
 {
-    // Reset DIO pins all-inputs.
-    for (size_t i = DIO_PORT_BASE; i < DIO_PORT_BASE + 4; ++i)
+    for (size_t i = DI_PORT_BASE; i < DI_PORT_BASE + NUM_DIS; ++i)
         gpio_init(i);
-    gpio_set_dir_masked64(DIO_PORT_MASK, 0); // 0-bits: input; 1-bits: output
+    for (size_t i = DO_PORT_BASE; i < DO_PORT_BASE + NUM_DOS; ++i)
+        gpio_init(i);
 
-    // TODO: Reset External Triggers to all-inputs.
+    // Reset External Triggers to all-inputs.
+    gpio_set_dir_masked64(DI_PORT_BASE, 0); // 0-bit: input.
+
+    // Reset Digital Outputs.
+    gpio_set_dir_masked64(DO_PORT_MASK, DO_PORT_MASK); // 1-bit: output.
+    gpio_set_put_masked64(digital_output_mask, 0); // Set all outputs LOW.
+
+    memset(&app_regs.waveform_hashes[0], 0, SHA256_NUM_BYTES);
+    memset(&app_regs.waveform_hashes[1], 0, SHA256_NUM_BYTES);
+    memset(&app_regs.waveform_hashes[2], 0, SHA256_NUM_BYTES);
+    memset(&app_regs.waveform_hashes[3], 0, SHA256_NUM_BYTES);
+    // TODO: open SD card, find hash files, update Harp reg hashes as needed.
 
     // FYI: PIO_LTC264x instances manage GPIO pin function.
+    for (const auto& dac: dacs)
+        dacs.write_value(DAC_MIDSCALE);
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        app_regs.analog_output_port_state[i] = DAC_MIDSCALE;
 
     // TODO: reset file player.
 }

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -12,10 +12,10 @@ RegSpecs app_reg_specs[APP_REG_COUNT]
     {(uint8_t*)&app_regs.ext_trigger_state, sizeof(app_regs.ext_trigger_state), U8},
 
     {(uint8_t*)&app_regs.analog_output_port_state, sizeof(app_regs.analog_output_port_state), U16},
-    {(uint8_t*)&app_regs.analog_output_channel_0, sizeof(app_regs.analog_output_channel_0), U16},
-    {(uint8_t*)&app_regs.analog_output_channel_1, sizeof(app_regs.analog_output_channel_1), U16},
-    {(uint8_t*)&app_regs.analog_output_channel_2, sizeof(app_regs.analog_output_channel_2), U16},
-    {(uint8_t*)&app_regs.analog_output_channel_3, sizeof(app_regs.analog_output_channel_3), U16},
+    {(uint8_t*)&app_regs.analog_output_port_state[0], sizeof(T), U16},
+    {(uint8_t*)&app_regs.analog_output_port_state[1], sizeof(T), U16},
+    {(uint8_t*)&app_regs.analog_output_port_state[2], sizeof(T), U16},
+    {(uint8_t*)&app_regs.analog_output_port_state[3], sizeof(T), U16},
 
     {(uint8_t*)&app_regs.dac_ready, sizeof(app_regs.dac_ready), U8},
     {(uint8_t*)&app_regs.dac_start, sizeof(app_regs.dac_start), U8},
@@ -174,13 +174,13 @@ void read_any_analog_output_channel(uint8_t address)
     if (HarpCore::is_muted())
         return;
     // Convert address to output channel.
-    uint32_t channel = address - AO_CHANNEL_BASE_ADDRESS;
+    size_t channel = address - AO_CHANNEL_BASE_ADDRESS;
     if (player.channel_is_busy(channel))
     {
         HarpCore::send_harp_reply(READ_ERROR, address);
         return;
     }
-    app_regs.analog_output_port_state[channel] = dacs[channel].get_last_value();
+    app_regs.analog_output_port_state[channel] = 0xBEEF;//dacs[channel].get_last_value();
     HarpCore::send_harp_reply(READ, address);
 }
 
@@ -188,8 +188,8 @@ void read_any_analog_output_channel(uint8_t address)
 void write_any_analog_output_channel(msg_t& msg)
 {
     // Convert address to output channel.
-    uint32_t channel = msg.header.address - AO_CHANNEL_BASE_ADDRESS;
-    if (player.channel_is_busy(channel))
+    size_t channel = msg.header.address - AO_CHANNEL_BASE_ADDRESS;
+    if (player.channel_is_busy(channel)) // FIXME: launch core1
     {
         if (!HarpCore::is_muted());
             HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
@@ -378,11 +378,14 @@ void reset_app()
 
     // Setup External Trigger Callback
     // Enable all External Trigger GPIOS to trigger the callback.
+    // FIXME: Get this working to launch from files.
+/*
+    irq_set_exclusive_handler(IO_IRQ_BANK0, handle_external_trigger);
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
         gpio_set_irq_enabled(i + DI_PORT_BASE, GPIO_IRQ_EDGE_RISE, true);
-    irq_add_shared_handler(IO_IRQ_BANK0, handle_external_trigger,
-                           GPIO_IRQ_CALLBACK_ORDER_PRIORITY);
     irq_set_enabled(IO_IRQ_BANK0, true);
+*/
+    // FIXME: how to reset core1.
 }
 
 void __not_in_flash_func(handle_external_trigger)()

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -12,10 +12,10 @@ RegSpecs app_reg_specs[APP_REG_COUNT]
     {(uint8_t*)&app_regs.ext_trigger_state, sizeof(app_regs.ext_trigger_state), U8},
 
     {(uint8_t*)&app_regs.analog_output_port_state, sizeof(app_regs.analog_output_port_state), U16},
-    {(uint8_t*)&app_regs.analog_output_port_state[0], sizeof(T), U16},
-    {(uint8_t*)&app_regs.analog_output_port_state[1], sizeof(T), U16},
-    {(uint8_t*)&app_regs.analog_output_port_state[2], sizeof(T), U16},
-    {(uint8_t*)&app_regs.analog_output_port_state[3], sizeof(T), U16},
+    {(uint8_t*)&app_regs.analog_output_channel_0, sizeof(T), U16},
+    {(uint8_t*)&app_regs.analog_output_channel_1, sizeof(T), U16},
+    {(uint8_t*)&app_regs.analog_output_channel_2, sizeof(T), U16},
+    {(uint8_t*)&app_regs.analog_output_channel_3, sizeof(T), U16},
 
     {(uint8_t*)&app_regs.dac_ready, sizeof(app_regs.dac_ready), U8},
     {(uint8_t*)&app_regs.dac_start, sizeof(app_regs.dac_start), U8},
@@ -180,7 +180,7 @@ void read_any_analog_output_channel(uint8_t address)
         HarpCore::send_harp_reply(READ_ERROR, address);
         return;
     }
-    app_regs.analog_output_port_state[channel] = 0xBEEF;//dacs[channel].get_last_value();
+    app_regs.analog_output_port_state[channel] = dacs[channel].get_last_value();
     HarpCore::send_harp_reply(READ, address);
 }
 
@@ -373,12 +373,11 @@ void reset_app()
         settings.frequency_hz = DEFAULT_FREQUENCY_HZ;
         settings.external_trigger_mask = (1u << i); // DI[i] triggers AO[i].
     }
-
+    multicore_reset_core1(); // Ensure core1 is not updating the player first.
     player.reset();
     player.set_frequency_hz(500'000);
     player.setup(); // FIXME: Locks up if the files don't exist.
     // Launch core1.
-    multicore_reset_core1();
     (void)multicore_fifo_pop_blocking(); // Wait until core1 is ready.
     multicore_launch_core1(core1main);
 

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -313,11 +313,20 @@ void update_app()
         while (queue_try_remove(&ext_trigger_event_queue, &trigger_event)){}
         return;
     }
+    // Dispatch any transfer-started events.
     while (queue_try_remove(&ext_trigger_event_queue, &trigger_event))
     {
         app_regs.dac_start = trigger_event.channel_start_mask;
         HarpCore::send_harp_reply(EVENT, DAC_START_ADDRESS,
             HarpCore::system_to_harp_us_64(trigger_event.timestamp));
+    }
+    // Dispatch any transfer-finished events.
+    end_of_transfer_event_t transfer_done_event;
+    while (player.get_finished_transfers(&event))
+    {
+        app_regs.dac_finished = uint8_t(transfer_done_event.finished_channels_mask);
+        HarpCore::send_harp_reply(EVENT, DAC_FINISHED_ADDRESS,
+            HarpCore::system_to_harp_us_64(event.timestamp_us));
     }
 }
 

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -1,6 +1,7 @@
 #include <quac_app.h>
 
 app_regs_t app_regs;
+queue_t ext_trigger_event_queue;
 
 RegSpecs app_reg_specs[APP_REG_COUNT]
 {
@@ -135,7 +136,23 @@ void write_dac_external_triggers(msg_t& msg)
 
 void read_analog_output_port_state(uint8_t address)
 {
-    // TODO
+    if (HarpCore::is_muted())
+        return;
+    // Ensure no channels are busy.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    {
+        if (!((app_regs.dac_start >> i) & 1u))
+            continue;
+        if (player.channel_is_busy(i))
+        {
+            HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+            return;
+        }
+    }
+    // Update register contents.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        app_regs.analog_output_port_state[i] = dacs[i].get_last_value();
+    HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
 
 
@@ -144,14 +161,13 @@ void write_analog_output_port_state(msg_t& msg)
     // Ensure no channels are busy.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (!((app_regs.dac_start >> i) & 1u))
-            continue;
-        if (!player.channel_is_ready(i))
+        if (player.channel_is_busy(i))
         {
             HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
             return;
         }
     }
+    HarpCore::copy_msg_payload_to_register(msg);
     // Apply the write.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
         dacs[i].write_value(app_regs.analog_output_port_state[i]);
@@ -162,16 +178,16 @@ void write_analog_output_port_state(msg_t& msg)
 
 void read_any_analog_output_channel(uint8_t address)
 {
+    if (HarpCore::is_muted())
+        return;
     // Convert address to output channel.
     uint32_t channel = address - AO_CHANNEL_BASE_ADDRESS;
     if (player.channel_is_busy(channel))
     {
-        HarCore::send_harp_reply(READ_ERROR, address);
+        HarpCore::send_harp_reply(READ_ERROR, address);
         return;
     }
     app_regs.analog_output_port_state[channel] = dacs[channel].get_last_value();
-    if (!HarpCore::is_muted())
-        HarCore::send_harp_reply(READ, address);
 }
 
 
@@ -181,7 +197,8 @@ void write_any_analog_output_channel(msg_t& msg)
     uint32_t channel = msg.header.address - AO_CHANNEL_BASE_ADDRESS;
     if (player.channel_is_busy(channel))
     {
-        HarCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+        if (!HarpCore::is_muted());
+            HarCore::send_harp_reply(WRITE_ERROR, msg.header.address);
         return;
     }
     HarpCore::copy_msg_payload_to_register(msg);
@@ -255,7 +272,20 @@ void read_any_dac_settings(uint8_t address)
 
 void write_any_dac_settings(msg_t& msg)
 {
-    // TODO: implement this.
+    // WriteError if we try to change the specified channel while it's busy.
+    // Convert address to output channel.
+    uint32_t channel = address - AO_CHANNEL_BASE_ADDRESS;
+    if (player.channel_is_busy(channel)
+    {
+        HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+        return;
+    }
+    HarpCore::copy_msg_payload_to_register();
+    // TODO: Send waveform settings to core1.
+    // ...
+    // ...
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(msg.header.address);
 }
 
 
@@ -269,13 +299,32 @@ void read_any_waveform_hash(uint8_t address)
 
 void write_any_waveform_data(msg_t& msg)
 {
-    // TODO: will need a custom implementation.
+    irq_set_enabled(IO_IRQ_BANK0, false); // disable external triggers.
+    // TODO: implement this. Will need to be pseudo-Harp spec.
+    // ...
+    // also update waveform hash.
+    // ...
+    irq_set_enabled(IO_IRQ_BANK0, true); // reenable external triggers.
 }
 
 void update_app()
 {
     // TODO: poll external triggers.
     // Start any externally triggered DACs if they are armed.
+
+    // Send Harp replies for externally-triggered events.
+    ext_trigger_event_t trigger_event;
+    if (HarpCore::is_muted()) // Drain the queue and exit.
+    {
+        while (queue_try_remove(&ext_trigger_event_queue, &trigger_event)){}
+        return;
+    }
+    while (queue_try_remove(&ext_trigger_event_queue, &trigger_event))
+    {
+        app_regs.dac_start = trigger_event.start_mask;
+        HarpCore::send_harp_reply(EVENT, DAC_START_ADDRESS,
+                                  system_to_harp_us_64(trigger_event.timestamp));
+    }
 }
 
 void reset_app()
@@ -305,4 +354,37 @@ void reset_app()
         app_regs.analog_output_port_state[i] = DAC_MIDSCALE;
 
     // TODO: reset file player.
+
+    // Setup External Trigger Callback
+    // Enable all External Trigger GPIOS to trigger the callback.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        gpio_set_irq_enabled(i + DI_PORT_BASE, GPIO_IRQ_EDGE_RISE, true);
+    irq_add_shared_handler(IO_IRQ_BANK0, handle_external_trigger,
+                           GPIO_IRQ_CALLBACK_ORDER_PRIORITY);
+    irq_set_enabled(IO_IRQ_BANK0, true);
+}
+
+void handle_external_trigger()
+{
+    // Start the waveform per the 1s in the channel.
+    // Filter out the busy channels first.
+    // TODO: consider an app_regs.IgnoredTriggers register?
+    uint32_t trigger_mask = ((gpio_get_all64() & DI_PORT_MASK) >> DI_PORT_BASE);
+    // Combine waveform settings external triggers to the final mask.
+    start_mask = 0;
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    {
+        if (player.channel_is_busy(i))
+            continue;
+        // Check if any currently HIGH pins would trigger this channel.
+        if (trigger_mask & app_regs.dac_settings[i].external_trigger_mask)
+            start_mask |= (1u << i);
+    }
+    start_mask &= composite_mask;
+    ext_trigger_event_t trigger_event;
+    player.start(start_mask); // Can be started from core1.
+    trigger_event.channel_mask = start_mask;
+    trigger_event.timestamp = time_us_64();
+    queue_try_add(&ext_trigger_event_queue, &trigger_event);
+    // Push harp message
 }

--- a/firmware/src/sd_hw_config.cpp
+++ b/firmware/src/sd_hw_config.cpp
@@ -12,7 +12,9 @@ static sd_sdio_if_t SD_SDIO_INTERFACE
 //    D2_gpio = D0_gpio + 2; -> derived from D0_gpio.
 //    D3_gpio = D0_gpio + 3; -> derived from D0_gpio.
     .SDIO_PIO = SD_PIO,
-    .baud_rate = SD_READ_SPEED_HZ
+    .DMA_IRQ_num = DMA_IRQ_0,
+    .use_exclusive_DMA_IRQ_handler = true,
+    .baud_rate = SD_READ_SPEED_HZ,
                                         // RP2040: */6 -> 20833333 Hz
 };
 

--- a/firmware/tests/buf_to_dac/src/main.cpp
+++ b/firmware/tests/buf_to_dac/src/main.cpp
@@ -6,17 +6,31 @@
 #include <hardware/pio.h>
 #include <pio_ltc264x.h>
 
-#define PICO_PIN (15)
-#define SCK_PIN (16)
-#define CS_PIN (17)
+#define PICO_PIN (4)
+#define SCK_PIN (5)
+#define CS_PIN (6)
 
+inline constexpr size_t LED0_PIN = 2;
+inline constexpr size_t LED1_PIN = 3;
+inline constexpr uint32_t LED_MASK = (1u << LED0_PIN) | (1u << LED1_PIN);
 
-static constexpr size_t BUFFER_SIZE = 512*32;
+inline constexpr size_t BUFFER_SIZE = 512*32;
+
+void irq_handler()
+{
+    dma_hw->ints0 = dma_hw->ints0; // Clear interrupt status.
+    gpio_put_masked(LED_MASK, 0xFFFFFFFF);
+}
 
 int main() {
     stdio_init_all();
     while (!stdio_usb_connected()){ sleep_ms(100);} // Wait for user to open com port.
     printf("Hello, world, from a Raspberry Pi Pico!\r\n");
+
+    gpio_init_mask(LED_MASK);
+    gpio_set_dir_masked(LED_MASK, 0xFFFFFFFF);
+    gpio_put_masked(LED_MASK, 0);
+
     PIO_LTC264x dac(pio0, SCK_PIN, PICO_PIN); // CS pin is <SCK pin> + 1
     dac.start();
 
@@ -26,17 +40,23 @@ int main() {
     dma_timer_set_fraction(dma_timer_chan, 1, 300); // numerator=1, denominator=300
     dreq_num_t pacing_signal = dreq_num_t(dma_get_timer_dreq(dma_timer_chan));
 
+    int irq_index = 0;
+
     // Create double-buffer.
     using T = uint16_t;
-    DMADoubleBuffer<T, BUFFER_SIZE> file_buf(pacing_signal, &pio0->txf[dac.sm_]);
+    DMADoubleBuffer<T, BUFFER_SIZE> file_buf(pacing_signal, &pio0->txf[dac.get_sm()]);
+    file_buf.enable_end_of_transfer_irq(irq_index);
     //In practice it will be: &pio0->txf[<state_machine_number]);
     // FIXME: we need to deal with 16-bit transfers, but the library accepts 32-bit-wide inputs.
 
-    printf("double buffer[0][]: %p\r\n", file_buf.buffers_[0]);
-    printf("double buffer[1][]: %p\r\n", file_buf.buffers_[1]);
-    printf("ctrl_chan_data_[0]: %p\r\n", file_buf.ctrl_chan_data_[0]);
-    printf("ctrl_chan_data_[1]: %p\r\n", file_buf.ctrl_chan_data_[1]);
-    printf("ctrl_chan read addr (as pointer): %p\r\n", dma_channel_hw_addr(file_buf.ctrl_chan_)->read_addr);
+    irq_set_exclusive_handler(DMA_IRQ_0 + irq_index, irq_handler);
+    irq_set_enabled(DMA_IRQ_0 + irq_index, true);
+
+    //printf("double buffer[0][]: %p\r\n", file_buf.buffers_[0]);
+    //printf("double buffer[1][]: %p\r\n", file_buf.buffers_[1]);
+    //printf("ctrl_chan_data_[0]: %p\r\n", file_buf.ctrl_chan_data_[0]);
+    //printf("ctrl_chan_data_[1]: %p\r\n", file_buf.ctrl_chan_data_[1]);
+    //printf("ctrl_chan read addr (as pointer): %p\r\n", dma_channel_hw_addr(file_buf.ctrl_chan_)->read_addr);
 
     // Load starting buffer with data.
     T* idle_buffer = file_buf.get_idle_buffer();

--- a/firmware/tests/multi_file_player/src/main.cpp
+++ b/firmware/tests/multi_file_player/src/main.cpp
@@ -10,15 +10,13 @@
 #include <multi_file_player.h>
 
 using T = uint16_t;
-inline constexpr size_t NUM_FILES = 1;
+inline constexpr size_t NUM_FILES = 4;
 inline constexpr size_t SD_CHUNK_SIZE = 32768;  // must be factor of 512.
 
 FIL __not_in_flash("file_handlers") fil[NUM_FILES];
 
-//std::array<const char*, NUM_FILES> filenames
-//{{"channel_0.txt", "channel_1.txt", "channel_2.txt", "channel_3.txt"}};
 std::array<const char*, NUM_FILES> filenames
-{{"channel_0.txt"}};
+{{"channel_0.bin", "channel_1.bin", "channel_2.bin", "channel_3.bin"}};
 
 struct DACPins
 {
@@ -29,22 +27,25 @@ struct DACPins
 
 std::array<DACPins, NUM_FILES> DAC_PINS
 {{
-    {.pico = 15, .sck = 16, .cs = 17},
-//    {.pico = 18, .sck = 19, .cs = 20},
-//    {.pico = 22, .sck = 23, .cs = 24},
-//    {.pico = 25, .sck = 26, .cs = 27}
+    {.pico = 4, .sck = 5, .cs = 6},
+    {.pico = 8, .sck = 9, .cs = 10},
+    {.pico = 12, .sck = 13, .cs = 14},
+    {.pico = 16, .sck = 17, .cs = 18}
 }};
 
 /* SDIO Interface */
 static sd_sdio_if_t sdio_if = {
 //  CLK_gpio = D0_gpio - 2; -> derived from D0_gpio.
-    .CMD_gpio = 3,
-    .D0_gpio = 4,
+    .CMD_gpio = 22,
+    .D0_gpio = 23,
 //    D1_gpio = D0_gpio + 1; -> derived from D0_gpio.
 //    D2_gpio = D0_gpio + 2; -> derived from D0_gpio.
 //    D3_gpio = D0_gpio + 3; -> derived from D0_gpio.
     .SDIO_PIO = pio0,
-    .baud_rate = 150 * 1000 * 1000 / 5, // RP2350: */5 -> 30000000 Hz
+    .DMA_IRQ_num = DMA_IRQ_0,
+    .use_exclusive_DMA_IRQ_handler = true,
+    .baud_rate = 150 * 1000 * 1000 / 6, // RP2350: */5 -> 30000000 Hz
+                                        // RP2350: */6 -> 25000000 Hz
 };
 
 /* Hardware Configuration of the SD Card socket "object" */
@@ -55,6 +56,7 @@ static sd_card_t sd_card = {.type = SD_IF_SDIO, .sdio_if_p = &sdio_if};
  * @return The number of SD cards, which is 1 in this case.
  */
 size_t sd_get_num() { return 1; }
+
 
 /**
  * @brief Get a pointer to an SD card object by its number.
@@ -67,6 +69,8 @@ sd_card_t* sd_get_by_num(size_t num) {
     else
     {return NULL;}
 }
+
+    extern MultiFilePlayer<T, NUM_FILES, SD_CHUNK_SIZE/sizeof(T)> player;
 
 int main() {
     UINT bytes_read;
@@ -83,15 +87,17 @@ int main() {
     // Setup PIO Block for DAC communication.
     std::array<PIO_LTC264x, NUM_FILES> dacs
     {{{pio2, DAC_PINS[0].sck, DAC_PINS[0].pico},
-    //  {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
-    //  {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},
-    //  {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()}}};
+      {pio2, DAC_PINS[1].sck, DAC_PINS[1].pico, false, dacs[0].get_offset()},
+      {pio2, DAC_PINS[2].sck, DAC_PINS[2].pico, false, dacs[0].get_offset()},
+      {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()}
     }};
     for (const auto& dac: dacs)
         dac.start();
 
     // Create MultiFilePlayer
     MultiFilePlayer<T, NUM_FILES, SD_CHUNK_SIZE/sizeof(T)> player(dacs, filenames);
+    // 1: DMA_IRQ_1 (FYI: sd card setup to use DMA_IRQ_0)
+    player.enable_end_of_transfer_interrupt(1);//, local_dma_handler);
     player.set_frequency_hz(500'000);
     player.setup();
     printf("File Player is ready.\r\n");
@@ -101,6 +107,12 @@ int main() {
     while(player.is_busy())
         player.update();
     printf("Done playing!\r\n");
+    end_of_transfer_event_t event;
+    while (player.get_finished_transfers(&event))
+    {
+        printf("Got end-of-transfer-event: (0b%032b, %llu [us])\r\n",
+               event.finished_channels_mask, event.timestamp_us);
+    }
     sleep_ms(1000);
 
     // If we did not abort, we should be able to re-trigger.
@@ -110,6 +122,11 @@ int main() {
     while(player.is_busy())
         player.update();
     printf("Done replaying! Closing files.\r\n");
+    while (player.get_finished_transfers(&event))
+    {
+        printf("Got end-of-transfer-event: (0b%032b, %llu [us])\r\n",
+               event.finished_channels_mask, event.timestamp_us);
+    }
 
     player.cleanup(); // Close files.
     // Unmount the file system.

--- a/software/pyharp/app_registers.py
+++ b/software/pyharp/app_registers.py
@@ -26,7 +26,7 @@ class AppRegs(IntEnum):
     DACSettings2 = 48
     DACSettings3 = 49
 
-    WaveformHashes0 = 40
+    WaveformHashes0 = 50
     WaveformHashes1 = 51
     WaveformHashes2 = 52
     WaveformHashes3 = 53

--- a/software/pyharp/app_registers.py
+++ b/software/pyharp/app_registers.py
@@ -18,20 +18,21 @@ class AppRegs(IntEnum):
     DACReady = 41
     DACStart = 42
     DACPause = 43
-    DACFinished = 44
+    DACAbort = 44
+    DACFinished = 45
 
-    DACSettings0 = 45
-    DACSettings1 = 46
-    DACSettings2 = 47
-    DACSettings3 = 48
+    DACSettings0 = 46
+    DACSettings1 = 47
+    DACSettings2 = 48
+    DACSettings3 = 49
 
-    WaveformHashes0 = 49
-    WaveformHashes1 = 50
-    WaveformHashes2 = 51
-    WaveformHashes3 = 52
+    WaveformHashes0 = 40
+    WaveformHashes1 = 51
+    WaveformHashes2 = 52
+    WaveformHashes3 = 53
 
-    WaveformData0 = 53
-    WaveformData1 = 52
-    WaveformData2 = 54
-    WaveformData3 = 55
+    WaveformData0 = 54
+    WaveformData1 = 55
+    WaveformData2 = 56
+    WaveformData3 = 57
 

--- a/software/pyharp/app_registers.py
+++ b/software/pyharp/app_registers.py
@@ -1,0 +1,37 @@
+"""App registers for the cuttlefish."""
+from enum import IntEnum
+
+
+class AppRegs(IntEnum):
+    DOPortState = 32
+    DOPortSet = 33
+    DOPortClear = 34
+
+    ExtTriggerState = 35
+
+    AOPortState = 36
+    AOChannel0 = 37
+    AOChannel1 = 38
+    AOChannel2 = 39
+    AOChannel0 = 40
+
+    DACReady = 41
+    DACStart = 42
+    DACPause = 43
+    DACFinished = 44
+
+    DACSettings0 = 45
+    DACSettings1 = 46
+    DACSettings2 = 47
+    DACSettings3 = 48
+
+    WaveformHashes0 = 49
+    WaveformHashes1 = 50
+    WaveformHashes2 = 51
+    WaveformHashes3 = 52
+
+    WaveformData0 = 53
+    WaveformData1 = 52
+    WaveformData2 = 54
+    WaveformData3 = 55
+

--- a/software/pyharp/app_registers.py
+++ b/software/pyharp/app_registers.py
@@ -13,7 +13,7 @@ class AppRegs(IntEnum):
     AOChannel0 = 37
     AOChannel1 = 38
     AOChannel2 = 39
-    AOChannel0 = 40
+    AOChannel3 = 40
 
     DACReady = 41
     DACStart = 42

--- a/software/pyharp/sw_trigger_single_shot_waveform.py
+++ b/software/pyharp/sw_trigger_single_shot_waveform.py
@@ -21,12 +21,12 @@ else: # assume Windows.
 
 for i in range(4):
     value = int(1) << i
-    print("Writing: 0x{value:02x}", end = " ")
-    reply = device.send(WriteU8HarpMessage(AppRegs.DACStart, i).frame)
-    print(f" Read back: 0x{reply.payload[0]:02x}")
-    sleep(1.0)
+    print(f"Writing: 0x{value:02x}", end = " ")
+    reply = device.send(WriteU8HarpMessage(AppRegs.DACStart, value).frame)
+    print(f" Read back: 0x{reply.payload[0]:02x} ({reply.message_type.name}), time: {reply.timestamp}")
+    sleep(0.5)
 
-printf("Waiting for end-of-message replies")
+print("Waiting for end-of-message replies")
 waveform_replies_left = 4
 while (waveform_replies_left):
     events = device.get_events()

--- a/software/pyharp/sw_trigger_single_shot_waveform.py
+++ b/software/pyharp/sw_trigger_single_shot_waveform.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from pyharp.device import Device, DeviceMode
+from pyharp.messages import WriteU8HarpMessage, WriteU8ArrayMessage
+from pyharp.messages import MessageType
+from pyharp.messages import CommonRegisters as Regs
+from struct import pack, unpack
+import logging
+import os
+from time import sleep
+from app_registers import AppRegs
+
+#logging.basicConfig(level=logging.DEBUG)
+
+
+# Open the device and print the info on screen
+# Open serial connection and save communication to a file
+if os.name == 'posix': # check for Linux.
+    device = Device("/dev/ttyACM0", "ibl.bin")
+else: # assume Windows.
+    device = Device("COM95", "ibl.bin")
+
+for i in range(4):
+    value = int(1) << i
+    print("Writing: 0x{value:02x}", end = " ")
+    reply = device.send(WriteU8HarpMessage(AppRegs.DACStart, i).frame)
+    print(f" Read back: 0x{reply.payload[0]:02x}")
+    sleep(1.0)
+
+printf("Waiting for end-of-message replies")
+waveform_replies_left = 4
+while (waveform_replies_left):
+    events = device.get_events()
+    for msg in events:
+        print(msg)
+        print()
+        if msg.address == AppRegs.DACFinished:
+            waveform_replies_left -= 1
+

--- a/software/pyharp/toggle_ao_port.py
+++ b/software/pyharp/toggle_ao_port.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from pyharp.device import Device, DeviceMode
-from pyharp.messages import WriteU8HarpMessage, WriteU8ArrayMessage
+from pyharp.messages import WriteU16HarpMessage, WriteU16ArrayMessage
 from pyharp.messages import MessageType
 from pyharp.messages import CommonRegisters as Regs
 from struct import pack, unpack
@@ -21,14 +21,15 @@ else: # assume Windows.
     device = Device("COM95", "ibl.bin")
 
 
-ao_value = random.randint(0, 65535)
 for i in range(4):
-    print("Writing: 0x{value:02x}", end = " ")
-    reply = device.send(WriteU8HarpMessage(AppRegs.AOChannel0 + i, ao_value).frame)
-    print(f" Read back: 0x{reply.payload[0]:02x}")
+    ao_value = random.randint(0, 65535)
+    print(f"Writing: 0x{ao_value:02x}", end = " ")
+    reply = device.send(WriteU16HarpMessage(AppRegs.AOChannel0 + i, ao_value).frame)
+    #print(f" Read back: 0x{reply.payload[0]:02x}")
+    print(reply)
     sleep(1.0)
 # Reset everything to midscale
 print(f"Resetting all Analog Output Waveforms to midscale.")
 midscale_settings = [32768, 32768, 32768, 32768]
 data_fmt = "<HHHH" # 4 unsigned 16-bit numbers.
-reply = device.send(WriteU8ArrayMessage(AppRegs.AOPortState, data_fmt, midscale_settings).frame)
+reply = device.send(WriteU16ArrayMessage(AppRegs.AOPortState, data_fmt, midscale_settings).frame)

--- a/software/pyharp/toggle_ao_port.py
+++ b/software/pyharp/toggle_ao_port.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from pyharp.device import Device, DeviceMode
+from pyharp.messages import WriteU8HarpMessage, WriteU8ArrayMessage
+from pyharp.messages import MessageType
+from pyharp.messages import CommonRegisters as Regs
+from struct import pack, unpack
+import logging
+import random
+import os
+from time import sleep
+from app_registers import AppRegs
+
+#logging.basicConfig(level=logging.DEBUG)
+
+
+# Open the device and print the info on screen
+# Open serial connection and save communication to a file
+if os.name == 'posix': # check for Linux.
+    device = Device("/dev/ttyACM0", "ibl.bin")
+else: # assume Windows.
+    device = Device("COM95", "ibl.bin")
+
+
+ao_value = random.randint(0, 65535)
+for i in range(4):
+    print("Writing: 0x{value:02x}", end = " ")
+    reply = device.send(WriteU8HarpMessage(AppRegs.AOChannel0 + i, ao_value).frame)
+    print(f" Read back: 0x{reply.payload[0]:02x}")
+    sleep(1.0)
+# Reset everything to midscale
+print(f"Resetting all Analog Output Waveforms to midscale.")
+midscale_settings = [32768, 32768, 32768, 32768]
+data_fmt = "<HHHH" # 4 unsigned 16-bit numbers.
+reply = device.send(WriteU8ArrayMessage(AppRegs.AOPortState, data_fmt, midscale_settings).frame)

--- a/software/pyharp/toggle_ao_port.py
+++ b/software/pyharp/toggle_ao_port.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from pyharp.device import Device, DeviceMode
-from pyharp.messages import WriteU16HarpMessage, WriteU16ArrayMessage
+from pyharp.messages import WriteU16HarpMessage, WriteU16ArrayMessage, ReadU16HarpMessage
 from pyharp.messages import MessageType
 from pyharp.messages import CommonRegisters as Regs
 from struct import pack, unpack
@@ -23,10 +23,12 @@ else: # assume Windows.
 
 for i in range(4):
     ao_value = random.randint(0, 65535)
-    print(f"Writing: 0x{ao_value:02x}", end = " ")
+    reply = device.send(ReadU16HarpMessage(AppRegs.AOChannel0 + i).frame)
+    print(f" AO[{i}] initial value: 0x{reply.payload[0]:04x}")
+    print(f"Writing: 0x{ao_value:04x}", end = " ")
     reply = device.send(WriteU16HarpMessage(AppRegs.AOChannel0 + i, ao_value).frame)
-    #print(f" Read back: 0x{reply.payload[0]:02x}")
-    print(reply)
+    print(f" | result: 0x{reply.payload[0]:04x}")
+    print()
     sleep(1.0)
 # Reset everything to midscale
 print(f"Resetting all Analog Output Waveforms to midscale.")

--- a/software/pyharp/toggle_do_port.py
+++ b/software/pyharp/toggle_do_port.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from pyharp.device import Device, DeviceMode
+from pyharp.messages import WriteU8HarpMessage, WriteU8ArrayMessage
+from pyharp.messages import MessageType
+from pyharp.messages import CommonRegisters as Regs
+from struct import pack, unpack
+import logging
+import os
+from time import sleep, perf_counter
+from app_registers import AppRegs
+
+#logging.basicConfig(level=logging.DEBUG)
+
+
+# Open the device and print the info on screen
+# Open serial connection and save communication to a file
+if os.name == 'posix': # check for Linux.
+    device = Device("/dev/ttyACM0", "ibl.bin")
+else: # assume Windows.
+    device = Device("COM95", "ibl.bin")
+
+for i in range(4):
+    value = int(1) << i
+    print("Writing: 0x{value:02x}", end = " ")
+    reply = device.send(WriteU8HarpMessage(AppRegs.DOPortState, i).frame)
+    print(f" Read back: 0x{reply.payload[0]:02x}")

--- a/software/pyharp/toggle_do_port.py
+++ b/software/pyharp/toggle_do_port.py
@@ -6,7 +6,7 @@ from pyharp.messages import CommonRegisters as Regs
 from struct import pack, unpack
 import logging
 import os
-from time import sleep, perf_counter
+from time import sleep
 from app_registers import AppRegs
 
 #logging.basicConfig(level=logging.DEBUG)
@@ -22,5 +22,8 @@ else: # assume Windows.
 for i in range(4):
     value = int(1) << i
     print("Writing: 0x{value:02x}", end = " ")
-    reply = device.send(WriteU8HarpMessage(AppRegs.DOPortState, i).frame)
+    reply = device.send(WriteU8HarpMessage(AppRegs.DOPortState, value).frame)
     print(f" Read back: 0x{reply.payload[0]:02x}")
+    sleep(0.5)
+print("Setting all Digital outputs to 0.")
+reply = device.send(WriteU8HarpMessage(AppRegs.DOPortState, 0).frame)

--- a/software/pyharp/wait_for_events.py
+++ b/software/pyharp/wait_for_events.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from pyharp.device import Device, DeviceMode
+from pyharp.messages import WriteU16HarpMessage, WriteU16ArrayMessage
+from pyharp.messages import MessageType
+from pyharp.messages import CommonRegisters as Regs
+from struct import pack, unpack
+import logging
+import random
+import os
+from time import sleep
+from app_registers import AppRegs
+
+#logging.basicConfig(level=logging.DEBUG)
+
+
+# Open the device and print the info on screen
+# Open serial connection and save communication to a file
+if os.name == 'posix': # check for Linux.
+    device = Device("/dev/ttyACM0", "ibl.bin")
+else: # assume Windows.
+    device = Device("COM95", "ibl.bin")
+
+
+print("Waiting for events.")
+try:
+    while True:
+        for event_msg in device.get_events():
+            print(event_msg)
+            print()
+except KeyboardInterrupt:
+    # Close connection
+    device.disconnect()


### PR DESCRIPTION
Heads-up: let's merge https://github.com/AllenNeuralDynamics/harp.device.quad-dac/pull/61 first.

This PR
* enables starting an AO channel waveform in one-shot (not looping) mode by Harp Message (SW Trigger) or External Trigger Pin
  * a finished waveform ends in "midscale" (0V).
  * partially implemented: external triggers can also be assigned to multiple AO channels.
* dispatches Harp messages when a waveform starts/finishes. Start messages . (Simultaneous starts/stops are captured concurrently.)
* enables writing single setpoint values to all digital outputs and analog outputs
* tweaks the Harp registers accordingly to support the above features
* adds a `device.yaml`
* adds some pyharp test files to test the above features.

## Implementation Details
Reading from the SD card and topping off the buffers for the four DACs is done by the `MultiFilePlayer` class. The bulk of this work is abstracted up to a single looping call to the `update()` function called on `core1`.  Meanwhile, Harp communication and interrupt-handling is currently all done by `core0`. Several `MultiFilePlayer` utility functions are multicore-safe so as to be able to call them from Harp callback functions on `core0`.

External "Start-Waveform" triggers are monitored by an interrupt service routine (ISR) setup on *core0* using rising-edge pin triggers on the 4 corresponding GPIO pins. The pins that triggered the waveforms are timestamped and stuffed into a queue.

`MultiFilePlayer` now triggers an ISR on *core0* when any waveform finishes using the DMA_IRQ hardware. This ISR checks identifies which AO channel finishes and stuffs a timestamped bitmask into the queue. Because the SD Card lib and `MultiFilePlayer` now use dma-based IRQs, we need to be explicit about who's using what and assign them a separate DMA_IRQ.

To keep all of these ISRs short, sending out Harp EVENT messages is done in the `update_app` loop by dequeueing pending data to send.


## Resolved Issues:
* https://github.com/AllenNeuralDynamics/harp.device.quad-dac/issues/62
* https://github.com/AllenNeuralDynamics/harp.device.quad-dac/issues/60
* https://github.com/AllenNeuralDynamics/harp.device.quad-dac/issues/59
* https://github.com/AllenNeuralDynamics/harp.device.quad-dac/issues/54
* https://github.com/AllenNeuralDynamics/harp.device.quad-dac/issues/47
* https://github.com/AllenNeuralDynamics/harp.device.quad-dac/issues/36