### PR TITLE
fix APP_REG_COUNT calc

### DIFF
--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -66,7 +66,7 @@ RegSpec app_reg_specs[]
     HarpCore::read_reg_error, write_any_waveform_data)
 };
 
-const size_t APP_REG_COUNT = sizeof(app_reg_specs);
+const size_t APP_REG_COUNT = sizeof(app_reg_specs)/sizeof(RegSpec);
 
 void read_digital_output_port_state(uint8_t address)
 {


### PR DESCRIPTION
One liner to fix the number of app registers. Calculating this wrong may cause the DUMP core register feature to crash.