### PR TITLE
Feat waveform generation

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,3 +1,17 @@
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 2.2.0)
+set(toolchainVersion 14_2_Rel1)
+set(picotoolVersion 2.2.0-a4)
+set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+if (EXISTS ${picoVscode})
+    include(${picoVscode})
+endif()
+# ====================================================================================
 cmake_minimum_required(VERSION 3.13)
 find_package(Git REQUIRED)
 execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD OUTPUT_VARIABLE COMMIT_ID OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -65,6 +79,21 @@ target_link_libraries(multi_file_player INTERFACE
     dma_double_buffer
     etl::etl
 )
+
+add_library(multi_waveform_player INTERFACE)
+target_sources(multi_waveform_player INTERFACE
+    inc/multi_waveform_player.h
+    inc/sine_wave_settings.h
+    inc/pulse_train_settings.h
+    inc/raised_cosine_lut.h
+)
+target_link_libraries(multi_waveform_player INTERFACE
+    pico_stdlib
+    pio_ltc264x
+    dma_double_buffer
+    multi_file_player
+)
+
 target_link_libraries(${PROJECT_NAME}
     pico_stdlib
     pio_ltc264x
@@ -72,6 +101,7 @@ target_link_libraries(${PROJECT_NAME}
     harp_sync
     #hardware_adc
     multi_file_player
+    multi_waveform_player
     pico_multicore
 )
 

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,17 +1,3 @@
-# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
-if(WIN32)
-    set(USERHOME $ENV{USERPROFILE})
-else()
-    set(USERHOME $ENV{HOME})
-endif()
-set(sdkVersion 2.2.0)
-set(toolchainVersion 14_2_Rel1)
-set(picotoolVersion 2.2.0-a4)
-set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
-if (EXISTS ${picoVscode})
-    include(${picoVscode})
-endif()
-# ====================================================================================
 cmake_minimum_required(VERSION 3.13)
 find_package(Git REQUIRED)
 execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD OUTPUT_VARIABLE COMMIT_ID OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -79,21 +65,6 @@ target_link_libraries(multi_file_player INTERFACE
     dma_double_buffer
     etl::etl
 )
-
-add_library(multi_waveform_player INTERFACE)
-target_sources(multi_waveform_player INTERFACE
-    inc/multi_waveform_player.h
-    inc/sine_wave_settings.h
-    inc/pulse_train_settings.h
-    inc/raised_cosine_lut.h
-)
-target_link_libraries(multi_waveform_player INTERFACE
-    pico_stdlib
-    pio_ltc264x
-    dma_double_buffer
-    multi_file_player
-)
-
 target_link_libraries(${PROJECT_NAME}
     pico_stdlib
     pio_ltc264x
@@ -101,7 +72,6 @@ target_link_libraries(${PROJECT_NAME}
     harp_sync
     #hardware_adc
     multi_file_player
-    multi_waveform_player
     pico_multicore
 )
 
@@ -113,4 +83,3 @@ if(DEBUG)
     pico_enable_stdio_uart(${PROJECT_NAME} 1) # UART stdio for printf.
     # Additional libraries need to have stdio init also.
 endif()
-

--- a/firmware/inc/core1_file_player.h
+++ b/firmware/inc/core1_file_player.h
@@ -3,12 +3,14 @@
 #include <config.h>
 #include <waveform_settings.h>
 #include <multi_file_player.h>
+#include <multi_waveform_player.h>
 #include <pico/util/queue.h>
 
 //extern queue_t waveform_settings_queue;
 //extern queue_t bulk_waveform_states_queue;
 
 extern MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE> player;
+extern MultiWaveformPlayer<T, NUM_CHANNELS, READ_BUF_SIZE> waveform_player;
 
 void core1main();
 

--- a/firmware/inc/multi_file_player.h
+++ b/firmware/inc/multi_file_player.h
@@ -61,6 +61,11 @@ public:
 
 /**
  * \brief setup the file reading loop
+ * \details opens each expected file on the SD card. Missing files are
+ *  tolerated: the corresponding channel stays in a "not file-backed" state
+ *  and `channel_is_busy()`/`channel_is_ready()` report false for it, so the
+ *  file player is a no-op for that channel. This lets the waveform player
+ *  drive channels even with no SD card inserted.
  */
     void setup()
     {
@@ -69,7 +74,8 @@ public:
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
             if (!file_is_open(id))
-                open_file(id);
+                (void)open_file(id);
+            is_file_mode_[id] = file_is_open(id);
         }
         // pre-read buffers.
         update();
@@ -89,6 +95,7 @@ public:
         std::ranges::fill(filptrs_, nullptr); // mark files as starting closed.
         std::ranges::fill(curr_iterations_, 0);
         std::ranges::fill(iterations_, 1);
+        std::ranges::fill(is_file_mode_, false); // no channel is file-backed yet.
         for (auto& dac: dacs_)
             dac.write_value(OUTPUT_MIDSCALE);
         cleanup(); // close all files.
@@ -112,21 +119,91 @@ public:
     inline bool file_is_open(size_t file_index)
     {return filptrs_[file_index] != nullptr;}
 
-    inline void open_file(size_t file_index)
+/**
+ * \brief attempt to open the given channel's file for reading.
+ * \return true on success, false if the file is missing or the SD card is
+ *  unavailable. Non-fatal so the device remains usable with no SD card.
+ */
+    inline bool open_file(size_t file_index)
     {
         FRESULT fr = f_open(&fils_[file_index], filenames_[file_index], FA_READ);
         if (fr != FR_OK)
-        {panic("Could not open: %s\r\n", filenames_[file_index]);}
+            return false;
         filptrs_[file_index] = &fils_[file_index]; // set ptr to indicate open file.
+        return true;
     }
 
     inline void close_file(size_t file_index)
     {
-        FRESULT fr = f_close(&fils_[file_index]);
-        if (fr != FR_OK)
-            panic("Could not close: %s\r\n.", filenames_[file_index]);
+        if (!file_is_open(file_index))
+            return;
+        (void)f_close(&fils_[file_index]);
         filptrs_[file_index] = nullptr; // clear ptr to indicate closed file.
     }
+
+/**
+ * \brief accessor for the underlying DMA double-buffer for a given channel.
+ * \note only intended to be called by a cooperating waveform generator that
+ *  wants to borrow the same DMA transport while the file player is idle on
+ *  that channel. See `abandon_files` / `reclaim_files`.
+ */
+    inline DMADoubleBuffer<T, BUF_SIZE>& get_file_buf(size_t channel_id)
+    {return file_bufs_[channel_id];}
+
+/**
+ * \brief release ownership of the specified channels so a cooperating
+ *  waveform generator can drive the DAC via the same DMA transport.
+ * \details aborts any in-flight transfer, closes the file (if open), and
+ *  marks the channel as not file-backed so `update()` skips it and the
+ *  busy checks return false for it.
+ */
+    void abandon_files(uint32_t mask)
+    {
+        for (size_t ch = 0; ch < NUM_CHANNELS; ++ch)
+        {
+            if (!(mask & (1u << ch)))
+                continue;
+            if (file_bufs_[ch].is_transferring())
+                file_bufs_[ch].abort_transfer();
+            if (file_is_open(ch))
+                close_file(ch);
+            is_file_mode_[ch] = false;
+            idle_buffers_[ch] = nullptr;
+            curr_iterations_[ch] = 0;
+        }
+    }
+
+/**
+ * \brief reclaim ownership of the specified channels, reopen their files
+ *  (if available), and re-prime their buffers.
+ * \note if a file cannot be opened, the channel stays in the not-file-backed
+ *  state. This is the symmetric operation for `abandon_files`.
+ */
+    void reclaim_files(uint32_t mask)
+    {
+        for (size_t ch = 0; ch < NUM_CHANNELS; ++ch)
+        {
+            if (!(mask & (1u << ch)))
+                continue;
+            file_bufs_[ch].abort_transfer();
+            file_bufs_[ch].reset_transfer_config();
+            if (!file_is_open(ch))
+                (void)open_file(ch);
+            is_file_mode_[ch] = file_is_open(ch);
+            idle_buffers_[ch] = nullptr;
+            curr_iterations_[ch] = 0;
+            if (is_file_mode_[ch])
+                f_rewind(&fils_[ch]);
+        }
+        // Prime buffers for the reclaimed channels.
+        update();
+    }
+
+/**
+ * \brief true if the specified channel is currently backed by an open file.
+ */
+    inline bool is_file_mode(size_t channel_id) const
+    {return is_file_mode_[channel_id];}
 
 /**
  * \brief close all open files.
@@ -367,9 +444,13 @@ public:
 /**
  * \brief true if the specified channel needs to be handled with periodic calls
  *  to update().
+ * \note a channel that has been abandoned (not file-backed) is not busy from
+ *  this player's perspective — some other cooperating player may own it.
  */
     inline bool channel_is_busy(size_t channel_id)
     {
+        if (!is_file_mode_[channel_id])
+            return false;
         if (channel_is_active(channel_id))
             return true;
         else if (!channel_is_armed(channel_id))
@@ -383,6 +464,8 @@ public:
     inline bool channel_is_ready(size_t channel_id)
     {
         // FIXME: validate that this will be multicore safe.
+        if (!is_file_mode_[channel_id])
+            return false;
         return (!channel_is_active(channel_id)) && channel_is_armed(channel_id);
     }
 
@@ -400,6 +483,10 @@ public:
         UINT bytes_read;
         for (size_t id = 0; id < NUM_CHANNELS; ++id)
         {
+            // Skip channels not owned by the file player (either never
+            // opened or explicitly abandoned to another source).
+            if (!is_file_mode_[id])
+                continue;
             // Skip if channel is ready but not transferring.
             bool channel_active = channel_is_active(id);
             bool channel_armed = channel_is_armed(id);
@@ -472,6 +559,7 @@ private:
     std::array<FIL*, NUM_CHANNELS> filptrs_;
     std::array<size_t, NUM_CHANNELS> iterations_;
     std::array<size_t, NUM_CHANNELS> curr_iterations_;
+    std::array<bool, NUM_CHANNELS> is_file_mode_{};
     etl::vector<DMADoubleBuffer<T, BUF_SIZE>, NUM_CHANNELS> file_bufs_;
     std::array<WaveformSettings, NUM_CHANNELS> settings_;
     int dma_timer_chan_;

--- a/firmware/inc/multi_waveform_player.h
+++ b/firmware/inc/multi_waveform_player.h
@@ -1,0 +1,428 @@
+#ifndef MULTI_WAVEFORM_PLAYER_H
+#define MULTI_WAVEFORM_PLAYER_H
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <hardware/dma.h>
+#include <dma_double_buffer.h>
+#include <multi_file_player.h>
+#include <sine_wave_settings.h>
+#include <pulse_train_settings.h>
+#include <raised_cosine_lut.h>
+
+/**
+ * \brief selects the waveform shape for a channel in the waveform player.
+ */
+enum class WaveformType : uint8_t
+{
+    Sine = 0,
+    PulseTrain = 1,
+};
+
+/**
+ * \brief generates raised-cosine sinusoids and trapezoidal pulse trains and
+ *  streams them to the DACs via the MultiFilePlayer's DMA transport.
+ *
+ * The waveform player does not own any DMA channels of its own; it borrows
+ * the ping-pong DMA buffers from the file player so that the two sources
+ * can coexist without exceeding the RP2350 DMA channel budget. At any moment
+ * a channel is owned by at most one source:
+ *   * `file_player.abandon_files(mask)` relinquishes a set of channels so the
+ *     waveform player can drive them.
+ *   * `file_player.reclaim_files(mask)` gives them back (reopens files,
+ *     re-primes buffers).
+ *
+ * Sample output is baselined at DAC midscale (0 V on the bipolar +/-10 V
+ * board). Raised-cosine sine output swings from midscale up to
+ * `midscale + amplitude`; trapezoidal pulses share the same convention for
+ * their flat-top value.
+ */
+template <typename T, size_t NUM_CHANNELS, size_t BUF_SIZE>
+class MultiWaveformPlayer
+{
+public:
+    static inline constexpr T OUTPUT_MIDSCALE = std::numeric_limits<T>::max() / 2;
+    static inline constexpr T OUTPUT_MAX      = std::numeric_limits<T>::max();
+    static inline constexpr uint32_t DEFAULT_SAMPLE_RATE_HZ = 10'000;
+
+    explicit MultiWaveformPlayer(MultiFilePlayer<T, NUM_CHANNELS, BUF_SIZE>& file_player)
+    : file_player_{file_player}, sample_rate_hz_{DEFAULT_SAMPLE_RATE_HZ}
+    {
+        reset();
+    }
+
+/**
+ * \brief clear all per-channel state. Does not touch the underlying DMA
+ *  transport (which lives on the file player).
+ * \warning not multicore safe.
+ */
+    void reset()
+    {
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+        {
+            active_[i]          = false;
+            idle_buffers_[i]    = nullptr;
+            phase_q32_[i]       = 0;
+            phase_inc_q32_[i]   = 0;
+            samples_emitted_[i] = 0;
+            samples_total_[i]   = 0;
+            period_counter_[i]  = 0;
+            interval_samples_[i]= 0;
+            width_samples_[i]   = 0;
+            ramp_on_samples_[i] = 0;
+            ramp_off_samples_[i]= 0;
+            waveform_type_[i]   = WaveformType::Sine;
+            sine_settings_[i]   = SineWaveSettings{};
+            pulse_settings_[i]  = PulseTrainSettings{};
+        }
+    }
+
+/**
+ * \brief cache the sample rate used to convert duration/interval parameters
+ *  from microseconds to samples at `start()` time.
+ * \note the actual DMA pacing timer lives on the file player; callers must
+ *  update both sides via `file_player.set_frequency_hz(hz)` at the same time.
+ */
+    void set_sample_rate_hz(uint32_t hz)
+    {sample_rate_hz_ = hz == 0 ? DEFAULT_SAMPLE_RATE_HZ : hz;}
+
+    uint32_t get_sample_rate_hz() const
+    {return sample_rate_hz_;}
+
+/**
+ * \brief latch the per-channel waveform parameters. Takes effect on the
+ *  next `start()`.
+ */
+    void set_sine_settings(size_t ch, const SineWaveSettings& s)
+    {sine_settings_[ch] = s;}
+
+    void set_pulse_settings(size_t ch, const PulseTrainSettings& s)
+    {pulse_settings_[ch] = s;}
+
+    void set_waveform_type(size_t ch, WaveformType t)
+    {waveform_type_[ch] = t;}
+
+    WaveformType get_waveform_type(size_t ch) const
+    {return waveform_type_[ch];}
+
+    const SineWaveSettings& get_sine_settings(size_t ch) const
+    {return sine_settings_[ch];}
+
+    const PulseTrainSettings& get_pulse_settings(size_t ch) const
+    {return pulse_settings_[ch];}
+
+/**
+ * \brief begin waveform playback on the specified channels.
+ * \details for each channel in \p mask:
+ *   * channel is taken from the file player via `abandon_files`.
+ *   * DMA config is reset and generator state is zeroed.
+ *   * the first ping-pong buffer is pre-filled via `update()`.
+ *   * the DMA chain is triggered.
+ * All channels in \p mask start simultaneously (single DMA trigger mask write).
+ * \note can be called from either core.
+ */
+    void start(uint32_t mask)
+    {
+        if (mask == 0)
+            return;
+        // Relinquish channels from the file player so its update() stops
+        // touching them.
+        file_player_.abandon_files(mask);
+        for (size_t ch = 0; ch < NUM_CHANNELS; ++ch)
+        {
+            if (!(mask & (1u << ch)))
+                continue;
+            auto& buf = file_player_.get_file_buf(ch);
+            buf.abort_transfer();
+            buf.reset_transfer_config();
+
+            // Reset generator state.
+            phase_q32_[ch]       = 0;
+            samples_emitted_[ch] = 0;
+            period_counter_[ch]  = 0;
+            idle_buffers_[ch]    = nullptr;
+
+            const uint64_t sr = sample_rate_hz_;
+            if (waveform_type_[ch] == WaveformType::Sine)
+            {
+                const SineWaveSettings& s = sine_settings_[ch];
+                // phase_inc = (freq * 2^32) / sample_rate.
+                phase_inc_q32_[ch] = static_cast<uint32_t>(
+                    (static_cast<uint64_t>(s.frequency_hz) << 32) / sr);
+                samples_total_[ch] = (s.duration_us == 0)
+                    ? 0u
+                    : static_cast<uint32_t>(
+                          (static_cast<uint64_t>(s.duration_us) * sr) / 1'000'000ull);
+            }
+            else // PulseTrain
+            {
+                const PulseTrainSettings& p = pulse_settings_[ch];
+                interval_samples_[ch] = static_cast<uint32_t>(
+                    (static_cast<uint64_t>(p.pulse_interval_us) * sr) / 1'000'000ull);
+                if (interval_samples_[ch] == 0)
+                    interval_samples_[ch] = 1; // avoid modulo-by-zero.
+                width_samples_[ch] = static_cast<uint32_t>(
+                    (static_cast<uint64_t>(p.pulse_width_us) * sr) / 1'000'000ull);
+                ramp_on_samples_[ch] = static_cast<uint32_t>(
+                    (static_cast<uint64_t>(p.ramp_on_duration_us) * sr) / 1'000'000ull);
+                ramp_off_samples_[ch] = static_cast<uint32_t>(
+                    (static_cast<uint64_t>(p.ramp_off_duration_us) * sr) / 1'000'000ull);
+                samples_total_[ch] = (p.total_duration_us == 0)
+                    ? 0u
+                    : static_cast<uint32_t>(
+                          (static_cast<uint64_t>(p.total_duration_us) * sr) / 1'000'000ull);
+            }
+            active_[ch] = true;
+        }
+        // Pre-fill the first ping-pong buffer for each requested channel.
+        update();
+        // Trigger all selected channels simultaneously via a single DMA
+        // control-channel trigger-mask write.
+        uint32_t trigger_mask = 0;
+        for (size_t ch = 0; ch < NUM_CHANNELS; ++ch)
+        {
+            if (!(mask & (1u << ch)))
+                continue;
+            trigger_mask |=
+                (1u << file_player_.get_file_buf(ch).get_ctrl_channel());
+        }
+        if (trigger_mask != 0)
+            dma_start_channel_mask(trigger_mask);
+    }
+
+/**
+ * \brief abort any in-flight waveform on the specified channels.
+ * \details the shared end-of-transfer ISR will still fire for the aborted
+ *  channels, which will push a finished-event that the app loop dispatches
+ *  as a waveform_finished Harp event.
+ */
+    void abort(uint32_t mask)
+    {
+        for (size_t ch = 0; ch < NUM_CHANNELS; ++ch)
+        {
+            if (!(mask & (1u << ch)) || !active_[ch])
+                continue;
+            file_player_.get_file_buf(ch).abort_transfer();
+        }
+    }
+
+/**
+ * \brief called by the app loop when a finished-transfer event was emitted
+ *  for channels owned by this player. Clears active state.
+ */
+    void note_finished(uint32_t mask)
+    {
+        for (size_t ch = 0; ch < NUM_CHANNELS; ++ch)
+        {
+            if (!(mask & (1u << ch)))
+                continue;
+            active_[ch] = false;
+        }
+    }
+
+/**
+ * \brief true if this player currently owns the specified channel.
+ */
+    inline bool channel_is_busy(size_t ch) const
+    {return active_[ch];}
+
+/**
+ * \brief true if the specified channel is currently armed and ready to start.
+ *  Used by the external-trigger handler.
+ */
+    inline bool channel_is_ready(size_t ch) const
+    {return !active_[ch];}
+
+/**
+ * \brief bitmask of channels currently owned by this player.
+ */
+    uint32_t active_channels_mask() const
+    {
+        uint32_t m = 0;
+        for (size_t i = 0; i < NUM_CHANNELS; ++i)
+            if (active_[i]) m |= (1u << i);
+        return m;
+    }
+
+/**
+ * \brief return the external-trigger DI mask configured for the given
+ *  channel's currently-selected waveform type.
+ */
+    uint8_t get_external_trigger_mask(size_t ch) const
+    {
+        return waveform_type_[ch] == WaveformType::Sine
+            ? sine_settings_[ch].external_trigger_mask
+            : pulse_settings_[ch].external_trigger_mask;
+    }
+
+/**
+ * \brief core1 update: refill the idle ping-pong buffer for each active
+ *  channel with freshly-generated samples, and terminate the DMA chain when
+ *  a bounded-duration waveform has emitted all of its samples.
+ */
+    void update()
+    {
+        for (size_t ch = 0; ch < NUM_CHANNELS; ++ch)
+        {
+            if (!active_[ch])
+                continue;
+            auto& buf = file_player_.get_file_buf(ch);
+
+            // If the last transfer was scheduled, wait for it to complete;
+            // its end-of-transfer IRQ will fire and the app loop will call
+            // note_finished() to clear active_[ch].
+            if (buf.dma_chain_loop_disconnected() && buf.is_transferring())
+                continue;
+
+            T* curr_idle = buf.get_idle_buffer();
+            if (curr_idle == nullptr)
+                continue;
+            if (idle_buffers_[ch] == curr_idle)
+                continue; // buffer hasn't switched yet.
+            idle_buffers_[ch] = curr_idle;
+
+            // Determine how many samples to emit into this buffer.
+            size_t to_generate = BUF_SIZE;
+            bool is_last = false;
+            if (samples_total_[ch] != 0)
+            {
+                uint32_t remaining = samples_total_[ch] - samples_emitted_[ch];
+                if (remaining <= BUF_SIZE)
+                {
+                    to_generate = remaining;
+                    is_last = true;
+                }
+            }
+            generate_chunk(ch, curr_idle, to_generate);
+            // Pad the trailing portion of a short final buffer with midscale
+            // so the DAC output sits at 0 V until the DMA terminates.
+            for (size_t i = to_generate; i < BUF_SIZE; ++i)
+                curr_idle[i] = OUTPUT_MIDSCALE;
+            samples_emitted_[ch] += static_cast<uint32_t>(to_generate);
+
+            if (is_last)
+            {
+                buf.setup_last_dma_transfer(to_generate);
+                // Clear idle tracking so we don't try to refill the (now
+                // doomed) buffer on subsequent update() calls before the
+                // end-of-transfer IRQ fires.
+                idle_buffers_[ch] = nullptr;
+            }
+        }
+    }
+
+private:
+    void generate_chunk(size_t ch, T* dst, size_t n)
+    {
+        if (waveform_type_[ch] == WaveformType::Sine)
+            generate_sine(ch, dst, n);
+        else
+            generate_pulse(ch, dst, n);
+    }
+
+    static inline T saturating_offset(uint32_t offset)
+    {
+        uint32_t sample = static_cast<uint32_t>(OUTPUT_MIDSCALE) + offset;
+        if (sample > OUTPUT_MAX)
+            sample = OUTPUT_MAX;
+        return static_cast<T>(sample);
+    }
+
+    void generate_sine(size_t ch, T* dst, size_t n)
+    {
+        uint32_t phase = phase_q32_[ch];
+        const uint32_t inc = phase_inc_q32_[ch];
+        const uint32_t amp = sine_settings_[ch].amplitude;
+        for (size_t i = 0; i < n; ++i)
+        {
+            const uint32_t idx  = phase >> 22;            // top 10 bits
+            const uint32_t next = (idx + 1) & RAISED_COSINE_LUT_MASK;
+            const uint32_t frac = phase & 0x003FFFFFu;    // low 22 bits
+            const int64_t a = static_cast<int64_t>(RAISED_COSINE_LUT[idx]);
+            const int64_t b = static_cast<int64_t>(RAISED_COSINE_LUT[next]);
+            // Linear interpolation in [0, 65535].
+            const int64_t interp =
+                a + ((b - a) * static_cast<int64_t>(frac)) / (int64_t(1) << 22);
+            const uint32_t shape = static_cast<uint32_t>(
+                interp < 0 ? 0 : (interp > 65535 ? 65535 : interp));
+            const uint32_t offset = (shape * amp) >> 16;
+            dst[i] = saturating_offset(offset);
+            phase += inc;
+        }
+        phase_q32_[ch] = phase;
+    }
+
+    void generate_pulse(size_t ch, T* dst, size_t n)
+    {
+        uint32_t t              = period_counter_[ch];
+        const uint32_t interval = interval_samples_[ch];
+        const uint32_t width    = width_samples_[ch];
+        const uint32_t ramp_on  = ramp_on_samples_[ch];
+        const uint32_t ramp_off = ramp_off_samples_[ch];
+        const uint32_t amp      = pulse_settings_[ch].pulse_amplitude;
+
+        const uint32_t plateau_end  = ramp_on + width;
+        const uint32_t ramp_down_end = plateau_end + ramp_off;
+
+        for (size_t i = 0; i < n; ++i)
+        {
+            uint32_t level = 0;
+            if (t < ramp_on)
+            {
+                level = (ramp_on == 0)
+                    ? amp
+                    : static_cast<uint32_t>(
+                        (static_cast<uint64_t>(amp) * t) / ramp_on);
+            }
+            else if (t < plateau_end)
+            {
+                level = amp;
+            }
+            else if (t < ramp_down_end)
+            {
+                const uint32_t dt = t - plateau_end;
+                level = (ramp_off == 0)
+                    ? 0
+                    : static_cast<uint32_t>(
+                        static_cast<uint64_t>(amp) -
+                        (static_cast<uint64_t>(amp) * dt) / ramp_off);
+            }
+            else
+            {
+                level = 0;
+            }
+            dst[i] = saturating_offset(level);
+            if (++t >= interval)
+                t = 0;
+        }
+        period_counter_[ch] = t;
+    }
+
+    MultiFilePlayer<T, NUM_CHANNELS, BUF_SIZE>& file_player_;
+    uint32_t sample_rate_hz_;
+
+    // Per-channel state.
+    std::array<bool, NUM_CHANNELS> active_{};
+    std::array<WaveformType, NUM_CHANNELS> waveform_type_{};
+    std::array<SineWaveSettings, NUM_CHANNELS> sine_settings_{};
+    std::array<PulseTrainSettings, NUM_CHANNELS> pulse_settings_{};
+    std::array<T*, NUM_CHANNELS> idle_buffers_{};
+
+    // Sine DDS state.
+    std::array<uint32_t, NUM_CHANNELS> phase_q32_{};
+    std::array<uint32_t, NUM_CHANNELS> phase_inc_q32_{};
+
+    // Pulse train state.
+    std::array<uint32_t, NUM_CHANNELS> period_counter_{};
+    std::array<uint32_t, NUM_CHANNELS> interval_samples_{};
+    std::array<uint32_t, NUM_CHANNELS> width_samples_{};
+    std::array<uint32_t, NUM_CHANNELS> ramp_on_samples_{};
+    std::array<uint32_t, NUM_CHANNELS> ramp_off_samples_{};
+
+    // Shared duration tracking.
+    std::array<uint32_t, NUM_CHANNELS> samples_emitted_{};
+    std::array<uint32_t, NUM_CHANNELS> samples_total_{}; // 0 = forever.
+};
+
+#endif // MULTI_WAVEFORM_PLAYER_H

--- a/firmware/inc/multi_waveform_player.h
+++ b/firmware/inc/multi_waveform_player.h
@@ -336,9 +336,9 @@ private:
         const uint32_t amp = sine_settings_[ch].amplitude;
         for (size_t i = 0; i < n; ++i)
         {
-            const uint32_t idx  = phase >> 22;            // top 10 bits
+            const uint32_t idx  = phase >> 22;            // top 10 bits from 32-bit integer
             const uint32_t next = (idx + 1) & RAISED_COSINE_LUT_MASK;
-            const uint32_t frac = phase & 0x003FFFFFu;    // low 22 bits
+            const uint32_t frac = phase & 0x003FFFFFu;    // low 22 bits from 32-bit integer
             const int64_t a = static_cast<int64_t>(RAISED_COSINE_LUT[idx]);
             const int64_t b = static_cast<int64_t>(RAISED_COSINE_LUT[next]);
             // Linear interpolation in [0, 65535].

--- a/firmware/inc/pulse_train_settings.h
+++ b/firmware/inc/pulse_train_settings.h
@@ -1,0 +1,29 @@
+#ifndef PULSE_TRAIN_SETTINGS_H
+#define PULSE_TRAIN_SETTINGS_H
+#include <cstdint>
+
+/**
+ * \brief settings for the pulse train generator (trapezoidal pulses).
+ *
+ * One period has four regions:
+ *   1) linear ramp 0 -> amplitude over ramp_on_duration_us
+ *   2) flat at amplitude for pulse_width_us
+ *   3) linear ramp amplitude -> 0 over ramp_off_duration_us
+ *   4) quiet at 0 for the remainder of pulse_interval_us
+ * The output is baselined at DAC midscale (0V on the bipolar +/-10V board),
+ * with a peak of `midscale + pulse_amplitude`.
+ */
+#pragma pack(push, 1)
+struct PulseTrainSettings
+{
+    uint32_t pulse_width_us;         // flat-top duration per pulse.
+    uint32_t pulse_interval_us;      // pulse-to-pulse period.
+    uint16_t pulse_amplitude;        // peak offset above midscale in DAC codes.
+    uint32_t ramp_on_duration_us;    // leading-edge ramp time.
+    uint32_t ramp_off_duration_us;   // trailing-edge ramp time.
+    uint32_t total_duration_us;      // 0 = run forever.
+    uint8_t  external_trigger_mask;  // DI pin(s) that arm this channel.
+};
+#pragma pack(pop)
+
+#endif // PULSE_TRAIN_SETTINGS_H

--- a/firmware/inc/quac_app.h
+++ b/firmware/inc/quac_app.h
@@ -3,9 +3,12 @@
 #include <harp_core.h>
 #include <harp_c_app.h>
 #include <waveform_settings.h>
+#include <sine_wave_settings.h>
+#include <pulse_train_settings.h>
 #include <array>
 #include <config.h>
 #include <multi_file_player.h>
+#include <multi_waveform_player.h>
 #include <pico/util/queue.h>
 #include <pico/multicore.h>
 #include <core1_file_player.h>
@@ -16,11 +19,21 @@ using enum reg_type_t;
 extern std::array<PIO_LTC264x, NUM_CHANNELS> dacs;
 extern queue_t ext_trigger_event_queue;
 extern MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE> player;
+extern MultiWaveformPlayer<T, NUM_CHANNELS, READ_BUF_SIZE> waveform_player;
 extern RegSpec app_reg_specs[];
 
 extern const size_t APP_REG_COUNT;
 inline constexpr size_t DAC_START_ADDRESS = HarpCore::APP_REG_START_ADDRESS + 10;
 inline constexpr size_t DAC_FINISHED_ADDRESS = HarpCore::APP_REG_START_ADDRESS + 13;
+// Offsets into the app-register table below DAC_FINISHED_ADDRESS's entry.
+// See app_reg_specs[] layout in quac_app.cpp for the authoritative order.
+inline constexpr size_t WAVEFORM_TYPE_BASE_ADDRESS    = HarpCore::APP_REG_START_ADDRESS + 26;
+inline constexpr size_t SINE_SETTINGS_BASE_ADDRESS    = HarpCore::APP_REG_START_ADDRESS + 30;
+inline constexpr size_t PULSE_SETTINGS_BASE_ADDRESS   = HarpCore::APP_REG_START_ADDRESS + 34;
+inline constexpr size_t WAVEFORM_START_ADDRESS        = HarpCore::APP_REG_START_ADDRESS + 38;
+inline constexpr size_t WAVEFORM_ABORT_ADDRESS        = HarpCore::APP_REG_START_ADDRESS + 39;
+inline constexpr size_t WAVEFORM_FINISHED_ADDRESS     = HarpCore::APP_REG_START_ADDRESS + 40;
+inline constexpr size_t SAMPLE_RATE_HZ_ADDRESS        = HarpCore::APP_REG_START_ADDRESS + 41;
 
 
 struct ext_trigger_event_t
@@ -59,6 +72,15 @@ struct app_regs_t
     uint8_t waveform_hashes[NUM_CHANNELS][SHA256_NUM_BYTES];
     // waveform_data are only exposed for write as individual registers.
     T waveform_data[NUM_CHANNELS]; // treat like a pointer. Data is stored on SD card.
+
+    // Waveform generator registers (MultiWaveformPlayer).
+    uint8_t waveform_type[NUM_CHANNELS];             // 0=Sine, 1=PulseTrain
+    SineWaveSettings sine_settings[NUM_CHANNELS];
+    PulseTrainSettings pulse_settings[NUM_CHANNELS];
+    uint8_t waveform_start;                          // write-only bitmask
+    uint8_t waveform_abort;                          // write-only bitmask
+    uint8_t waveform_finished;                       // EVENT payload
+    uint32_t sample_rate_hz;                         // shared DMA pacing rate
 };
 #pragma pack(pop)
 
@@ -96,6 +118,21 @@ void write_any_dac_settings(msg_t& msg);
 void read_any_waveform_hash(uint8_t address);
 
 void write_any_waveform_data(msg_t& msg);
+
+void read_any_waveform_type(uint8_t address);
+void write_any_waveform_type(msg_t& msg);
+
+void read_any_sine_settings(uint8_t address);
+void write_any_sine_settings(msg_t& msg);
+
+void read_any_pulse_settings(uint8_t address);
+void write_any_pulse_settings(msg_t& msg);
+
+void write_waveform_start(msg_t& msg);
+void write_waveform_abort(msg_t& msg);
+
+void read_sample_rate_hz(uint8_t address);
+void write_sample_rate_hz(msg_t& msg);
 
 void reset_app();
 

--- a/firmware/inc/raised_cosine_lut.h
+++ b/firmware/inc/raised_cosine_lut.h
@@ -14,7 +14,7 @@
  * is enough for sub-Hz sinusoids at a 10 kHz sample rate (10k samples/cycle).
  */
 
-inline constexpr size_t RAISED_COSINE_LUT_SIZE = 1024;
+inline constexpr size_t RAISED_COSINE_LUT_SIZE = 1024;  // must be a power of 2
 inline constexpr size_t RAISED_COSINE_LUT_MASK = RAISED_COSINE_LUT_SIZE - 1;
 
 namespace quac_detail

--- a/firmware/inc/raised_cosine_lut.h
+++ b/firmware/inc/raised_cosine_lut.h
@@ -1,0 +1,61 @@
+#ifndef RAISED_COSINE_LUT_H
+#define RAISED_COSINE_LUT_H
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * \file raised_cosine_lut.h
+ * \brief compile-time raised-cosine lookup table for the sine generator.
+ *
+ * The LUT stores (1 - cos(2*pi*i/N))/2 in the range [0, 65535] for
+ * i = 0 .. N-1. Using 10 MSBs of a Q32 phase accumulator plus the 22 LSBs
+ * as a linear-interpolation weight gives ~20-bit effective resolution, which
+ * is enough for sub-Hz sinusoids at a 10 kHz sample rate (10k samples/cycle).
+ */
+
+inline constexpr size_t RAISED_COSINE_LUT_SIZE = 1024;
+inline constexpr size_t RAISED_COSINE_LUT_MASK = RAISED_COSINE_LUT_SIZE - 1;
+
+namespace quac_detail
+{
+/// Compile-time cosine via truncated Taylor series. Good to ~1e-12 over
+/// the argument range after modular reduction.
+consteval double cexpr_cos(double x)
+{
+    constexpr double pi = 3.14159265358979323846;
+    constexpr double two_pi = 2.0 * pi;
+    // Reduce x to (-pi, pi].
+    while (x > pi)      x -= two_pi;
+    while (x <= -pi)    x += two_pi;
+    double x2 = x * x;
+    double term = 1.0;
+    double result = 1.0;
+    for (int n = 1; n < 18; ++n)
+    {
+        term = -term * x2 / double((2 * n - 1) * (2 * n));
+        result += term;
+    }
+    return result;
+}
+
+consteval std::array<uint16_t, RAISED_COSINE_LUT_SIZE> make_raised_cosine_lut()
+{
+    constexpr double pi = 3.14159265358979323846;
+    std::array<uint16_t, RAISED_COSINE_LUT_SIZE> lut{};
+    for (size_t i = 0; i < RAISED_COSINE_LUT_SIZE; ++i)
+    {
+        double phase = 2.0 * pi * double(i) / double(RAISED_COSINE_LUT_SIZE);
+        double normalized = (1.0 - cexpr_cos(phase)) / 2.0; // [0, 1]
+        double scaled = normalized * 65535.0 + 0.5;
+        if (scaled > 65535.0) scaled = 65535.0;
+        if (scaled < 0.0)     scaled = 0.0;
+        lut[i] = static_cast<uint16_t>(scaled);
+    }
+    return lut;
+}
+} // namespace quac_detail
+
+inline constexpr auto RAISED_COSINE_LUT = quac_detail::make_raised_cosine_lut();
+
+#endif // RAISED_COSINE_LUT_H

--- a/firmware/inc/sine_wave_settings.h
+++ b/firmware/inc/sine_wave_settings.h
@@ -1,0 +1,22 @@
+#ifndef SINE_WAVE_SETTINGS_H
+#define SINE_WAVE_SETTINGS_H
+#include <cstdint>
+
+/**
+ * \brief settings for the raised-cosine sine generator.
+ *
+ * Output on the bipolar +/-10V DAC swings from 0V (DAC midscale) upward to
+ * `amplitude` DAC codes above midscale, following
+ *      sample = midscale + amplitude * (1 - cos(phase)) / 2.
+ */
+#pragma pack(push, 1)
+struct SineWaveSettings
+{
+    uint32_t frequency_hz;          // signal frequency (distinct from sample rate).
+    uint32_t duration_us;           // 0 = run forever.
+    uint16_t amplitude;             // peak offset above midscale in DAC codes.
+    uint8_t  external_trigger_mask; // DI pin(s) that arm this channel.
+};
+#pragma pack(pop)
+
+#endif // SINE_WAVE_SETTINGS_H

--- a/firmware/src/core1_file_player.cpp
+++ b/firmware/src/core1_file_player.cpp
@@ -3,6 +3,11 @@
 void core1main()
 {
     // Note: Commands like Pause/Resume/Stop are handled by core0.
+    // Each player only services the channels it currently owns; the other's
+    // update() is a cheap no-op for those channels.
     while (true)
+    {
         player.update();
+        waveform_player.update();
+    }
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -30,6 +30,7 @@ std::array<PIO_LTC264x, NUM_CHANNELS> dacs
     {pio2, DAC_PINS[3].sck, DAC_PINS[3].pico, false, dacs[0].get_offset()},
 }};
 MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE> player(dacs, filenames);
+MultiWaveformPlayer<T, NUM_CHANNELS, READ_BUF_SIZE> waveform_player(player);
 
 // Core0 main.
 int main()

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -247,7 +247,7 @@ void write_dac_start(msg_t& msg)
     // Ensure specified channels are ready and not owned by the waveform player.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (!((mask >> i) & 1u))
+        if (!((mask >> i) & 1u)) // Skip untriggered channels.
             continue;
         if (waveform_player.channel_is_busy(i) || !player.channel_is_ready(i))
         {

--- a/firmware/src/quac_app.cpp
+++ b/firmware/src/quac_app.cpp
@@ -63,10 +63,51 @@ RegSpec app_reg_specs[]
     RegSpec::U8Array(&app_regs.waveform_hashes[0], 1,
         HarpCore::read_reg_error, write_any_waveform_data),
     RegSpec::U8Array(&app_regs.waveform_hashes[0], 1,
-    HarpCore::read_reg_error, write_any_waveform_data)
+    HarpCore::read_reg_error, write_any_waveform_data),
+
+    // --- MultiWaveformPlayer registers (indices 26 onward). ---
+    RegSpec::U8(&app_regs.waveform_type[0],
+        read_any_waveform_type, write_any_waveform_type),
+    RegSpec::U8(&app_regs.waveform_type[1],
+        read_any_waveform_type, write_any_waveform_type),
+    RegSpec::U8(&app_regs.waveform_type[2],
+        read_any_waveform_type, write_any_waveform_type),
+    RegSpec::U8(&app_regs.waveform_type[3],
+        read_any_waveform_type, write_any_waveform_type),
+
+    RegSpec::U8Array(&app_regs.sine_settings[0], sizeof(SineWaveSettings),
+        read_any_sine_settings, write_any_sine_settings),
+    RegSpec::U8Array(&app_regs.sine_settings[1], sizeof(SineWaveSettings),
+        read_any_sine_settings, write_any_sine_settings),
+    RegSpec::U8Array(&app_regs.sine_settings[2], sizeof(SineWaveSettings),
+        read_any_sine_settings, write_any_sine_settings),
+    RegSpec::U8Array(&app_regs.sine_settings[3], sizeof(SineWaveSettings),
+        read_any_sine_settings, write_any_sine_settings),
+
+    RegSpec::U8Array(&app_regs.pulse_settings[0], sizeof(PulseTrainSettings),
+        read_any_pulse_settings, write_any_pulse_settings),
+    RegSpec::U8Array(&app_regs.pulse_settings[1], sizeof(PulseTrainSettings),
+        read_any_pulse_settings, write_any_pulse_settings),
+    RegSpec::U8Array(&app_regs.pulse_settings[2], sizeof(PulseTrainSettings),
+        read_any_pulse_settings, write_any_pulse_settings),
+    RegSpec::U8Array(&app_regs.pulse_settings[3], sizeof(PulseTrainSettings),
+        read_any_pulse_settings, write_any_pulse_settings),
+
+    RegSpec::U8(&app_regs.waveform_start,
+        HarpCore::read_reg_error, write_waveform_start),
+    RegSpec::U8(&app_regs.waveform_abort,
+        HarpCore::read_reg_error, write_waveform_abort),
+    RegSpec::U8(&app_regs.waveform_finished,
+        HarpCore::read_reg_error, HarpCore::write_reg_error),
+    RegSpec::U32(&app_regs.sample_rate_hz,
+        read_sample_rate_hz, write_sample_rate_hz)
 };
 
 const size_t APP_REG_COUNT = sizeof(app_reg_specs);
+
+// Helper: true if the channel is owned by either player.
+static inline bool any_player_busy(size_t ch)
+{return player.channel_is_busy(ch) || waveform_player.channel_is_busy(ch);}
 
 void read_digital_output_port_state(uint8_t address)
 {
@@ -120,10 +161,10 @@ void read_analog_output_port_state(uint8_t address)
 {
     if (HarpCore::is_muted())
         return;
-    // Ensure no channels are busy.
+    // Ensure no channels are busy in either player.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (player.channel_is_busy(i))
+        if (any_player_busy(i))
         {
             HarpCore::send_harp_reply(READ_ERROR, address);
             return;
@@ -138,10 +179,10 @@ void read_analog_output_port_state(uint8_t address)
 
 void write_analog_output_port_state(msg_t& msg)
 {
-    // Ensure no channels are busy.
+    // Ensure no channels are busy in either player.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (player.channel_is_busy(i))
+        if (any_player_busy(i))
         {
             HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
             return;
@@ -163,7 +204,7 @@ void read_any_analog_output_channel(uint8_t address)
     // Convert address to output channel with pointer arithmetic.
     const RegSpec& specs = HarpCore::reg_address_to_spec(address);
     size_t channel = ((uint16_t*)specs.base_ptr - app_regs.analog_output_port_state);
-    if (player.channel_is_busy(channel))
+    if (any_player_busy(channel))
     {
         HarpCore::send_harp_reply(READ_ERROR, address);
         return;
@@ -178,7 +219,7 @@ void write_any_analog_output_channel(msg_t& msg)
     // Convert address to output channel with pointer arithmetic.
     const RegSpec& specs = HarpCore::reg_address_to_spec(msg.header.address);
     size_t channel = ((uint16_t*)specs.base_ptr - app_regs.analog_output_port_state);
-    if (player.channel_is_busy(channel)) // FIXME: launch core1
+    if (any_player_busy(channel)) // FIXME: launch core1
     {
         if (!HarpCore::is_muted());
             HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
@@ -202,19 +243,19 @@ void write_dac_start(msg_t& msg)
 {
     // TODO: handle paused logic.
     HarpCore::copy_msg_payload_to_register(msg);
-    // Ensure specified channels are ready.
+    const uint32_t mask = uint32_t(app_regs.dac_start);
+    // Ensure specified channels are ready and not owned by the waveform player.
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (!((app_regs.dac_start >> i) & 1u)) // Skip untriggered channels.
+        if (!((mask >> i) & 1u))
             continue;
-        // Error if any specified channel is not ready.
-        if (!player.channel_is_ready(i))
+        if (waveform_player.channel_is_busy(i) || !player.channel_is_ready(i))
         {
             HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
             return;
         }
     }
-    player.start(uint32_t(app_regs.dac_start)); // Can be started from core0.
+    player.start(mask); // Can be started from core0.
     if (!HarpCore::is_muted())
         HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
@@ -247,18 +288,17 @@ void read_any_dac_settings(uint8_t address)
 void write_any_dac_settings(msg_t& msg)
 {
     // WriteError if we try to change the specified channel while it's busy.
-    // Convert address to output channel with pointer arithmetic.
+    // Recover the channel index from this spec's base pointer.
     const RegSpec& spec = HarpCore::reg_address_to_spec(msg.header.address);
-    size_t channel = ((uint16_t*)spec.base_ptr - app_regs.analog_output_port_state);
-    if (player.channel_is_busy(channel))
+    size_t channel = (static_cast<WaveformSettings*>(const_cast<void*>(spec.base_ptr))
+                      - &app_regs.dac_settings[0]);
+    if (any_player_busy(channel))
     {
         HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
         return;
     }
     HarpCore::copy_msg_payload_to_register(msg);
     // TODO: Send waveform settings to core1.
-    // ...
-    // ...
     if (!HarpCore::is_muted())
         HarpCore::send_harp_reply(WRITE, msg.header.address);
 }
@@ -283,6 +323,141 @@ void write_any_waveform_data(msg_t& msg)
 }
 
 
+// --- MultiWaveformPlayer register callbacks. ---
+
+static inline size_t waveform_type_channel_from_spec(const RegSpec& spec)
+{
+    return (static_cast<uint8_t*>(const_cast<void*>(spec.base_ptr))
+            - &app_regs.waveform_type[0]);
+}
+
+
+void read_any_waveform_type(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_any_waveform_type(msg_t& msg)
+{
+    const RegSpec& spec = HarpCore::reg_address_to_spec(msg.header.address);
+    size_t channel = waveform_type_channel_from_spec(spec);
+    if (any_player_busy(channel))
+    {
+        HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+        return;
+    }
+    HarpCore::copy_msg_payload_to_register(msg);
+    const uint8_t raw = app_regs.waveform_type[channel];
+    // Clamp unknown values to Sine.
+    WaveformType t = (raw == uint8_t(WaveformType::PulseTrain))
+        ? WaveformType::PulseTrain
+        : WaveformType::Sine;
+    app_regs.waveform_type[channel] = uint8_t(t);
+    waveform_player.set_waveform_type(channel, t);
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void read_any_sine_settings(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_any_sine_settings(msg_t& msg)
+{
+    const RegSpec& spec = HarpCore::reg_address_to_spec(msg.header.address);
+    size_t channel = (static_cast<SineWaveSettings*>(const_cast<void*>(spec.base_ptr))
+                      - &app_regs.sine_settings[0]);
+    if (any_player_busy(channel))
+    {
+        HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+        return;
+    }
+    HarpCore::copy_msg_payload_to_register(msg);
+    waveform_player.set_sine_settings(channel, app_regs.sine_settings[channel]);
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void read_any_pulse_settings(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_any_pulse_settings(msg_t& msg)
+{
+    const RegSpec& spec = HarpCore::reg_address_to_spec(msg.header.address);
+    size_t channel = (static_cast<PulseTrainSettings*>(const_cast<void*>(spec.base_ptr))
+                      - &app_regs.pulse_settings[0]);
+    if (any_player_busy(channel))
+    {
+        HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+        return;
+    }
+    HarpCore::copy_msg_payload_to_register(msg);
+    waveform_player.set_pulse_settings(channel, app_regs.pulse_settings[channel]);
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void write_waveform_start(msg_t& msg)
+{
+    HarpCore::copy_msg_payload_to_register(msg);
+    const uint32_t mask = uint32_t(app_regs.waveform_start);
+    // Every requested channel must be idle in both players.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    {
+        if (!((mask >> i) & 1u))
+            continue;
+        if (any_player_busy(i))
+        {
+            HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+            return;
+        }
+    }
+    waveform_player.start(mask);
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void write_waveform_abort(msg_t& msg)
+{
+    HarpCore::copy_msg_payload_to_register(msg);
+    waveform_player.abort(uint32_t(app_regs.waveform_abort));
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
+void read_sample_rate_hz(uint8_t address)
+{HarpCore::read_reg_generic(address);}
+
+
+void write_sample_rate_hz(msg_t& msg)
+{
+    // Reject if any channel is active — changing the shared DMA timer under
+    // an in-flight transfer is unsafe.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    {
+        if (any_player_busy(i))
+        {
+            HarpCore::send_harp_reply(WRITE_ERROR, msg.header.address);
+            return;
+        }
+    }
+    HarpCore::copy_msg_payload_to_register(msg);
+    uint32_t hz = app_regs.sample_rate_hz;
+    if (hz == 0)
+        hz = MultiWaveformPlayer<T, NUM_CHANNELS, READ_BUF_SIZE>::DEFAULT_SAMPLE_RATE_HZ;
+    player.set_frequency_hz(hz);
+    waveform_player.set_sample_rate_hz(hz);
+    app_regs.sample_rate_hz = hz;
+    if (!HarpCore::is_muted())
+        HarpCore::send_harp_reply(WRITE, msg.header.address);
+}
+
+
 void update_app()
 {
     // FYI: external triggers are handled via interrupts on this core,
@@ -296,22 +471,40 @@ void update_app()
     if (HarpCore::is_muted())
     {
         while (queue_try_remove(&ext_trigger_event_queue, &trigger_event)){}
-        while (player.get_finished_transfers(&transfer_done_event)){}
+        while (player.get_finished_transfers(&transfer_done_event))
+            waveform_player.note_finished(transfer_done_event.finished_channels_mask
+                & waveform_player.active_channels_mask());
         return;
     }
     // Dispatch any externally-triggered transfer-started events.
     while (queue_try_remove(&ext_trigger_event_queue, &trigger_event))
     {
+        // FYI: the trigger event records the raw start mask; waveform-mode
+        // starts are currently USB-triggered only, so file-mode is implied.
         app_regs.dac_start = trigger_event.channel_start_mask;
         HarpCore::send_harp_reply(EVENT, DAC_START_ADDRESS,
             HarpCore::system_to_harp_us_64(trigger_event.timestamp));
     }
-    // Dispatch any transfer-finished events.
+    // Dispatch any transfer-finished events. Split the mask between file- and
+    // waveform-mode owners so each source gets the correct Harp event address.
     while (player.get_finished_transfers(&transfer_done_event))
     {
-        app_regs.dac_finished = uint8_t(transfer_done_event.finished_channels_mask);
-        HarpCore::send_harp_reply(EVENT, DAC_FINISHED_ADDRESS,
-            HarpCore::system_to_harp_us_64(transfer_done_event.timestamp_us));
+        const uint32_t finished = transfer_done_event.finished_channels_mask;
+        const uint32_t wv_mask  = finished & waveform_player.active_channels_mask();
+        const uint32_t fp_mask  = finished & ~wv_mask;
+        if (fp_mask)
+        {
+            app_regs.dac_finished = uint8_t(fp_mask);
+            HarpCore::send_harp_reply(EVENT, DAC_FINISHED_ADDRESS,
+                HarpCore::system_to_harp_us_64(transfer_done_event.timestamp_us));
+        }
+        if (wv_mask)
+        {
+            app_regs.waveform_finished = uint8_t(wv_mask);
+            HarpCore::send_harp_reply(EVENT, WAVEFORM_FINISHED_ADDRESS,
+                HarpCore::system_to_harp_us_64(transfer_done_event.timestamp_us));
+            waveform_player.note_finished(wv_mask);
+        }
     }
 }
 
@@ -338,26 +531,60 @@ void reset_app()
     // FYI: PIO_LTC264x instances manage GPIO pin function.
     const T& DAC_MIDSCALE =
         MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE>::OUTPUT_MIDSCALE;
-    const size_t DEFAULT_FREQUENCY_HZ =
-        MultiFilePlayer<T, NUM_CHANNELS, READ_BUF_SIZE>::DEFAULT_FREQUENCY_HZ;
+    constexpr uint32_t DEFAULT_WAVEFORM_SAMPLE_RATE_HZ =
+        MultiWaveformPlayer<T, NUM_CHANNELS, READ_BUF_SIZE>::DEFAULT_SAMPLE_RATE_HZ;
 
     for (auto& dac: dacs)
         dac.write_value(DAC_MIDSCALE);
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
         app_regs.analog_output_port_state[i] = DAC_MIDSCALE;
-    // Reset Waveform trigger settings.
+    // Reset file-player WaveformSettings (file-mode external triggers).
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
         auto& settings = app_regs.dac_settings[i];
         settings.cycles = 1; // play once: "single-shot."
         settings.sample_count = 0; // Play everything.
-        settings.frequency_hz = DEFAULT_FREQUENCY_HZ;
+        settings.frequency_hz = DEFAULT_WAVEFORM_SAMPLE_RATE_HZ;
         settings.external_trigger_mask = (1u << i); // DI[i] triggers AO[i].
     }
+    // Reset waveform-player registers to sensible defaults.
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    {
+        app_regs.waveform_type[i] = uint8_t(WaveformType::Sine);
+        app_regs.sine_settings[i] = SineWaveSettings{
+            .frequency_hz = 1000,         // 1 kHz default.
+            .duration_us = 1'000'000,     // 1 s default.
+            .amplitude = DAC_MIDSCALE / 2,
+            .external_trigger_mask = uint8_t(1u << i),
+        };
+        app_regs.pulse_settings[i] = PulseTrainSettings{
+            .pulse_width_us = 1000,
+            .pulse_interval_us = 10'000,
+            .pulse_amplitude = DAC_MIDSCALE / 2,
+            .ramp_on_duration_us = 0,
+            .ramp_off_duration_us = 0,
+            .total_duration_us = 1'000'000,
+            .external_trigger_mask = uint8_t(1u << i),
+        };
+    }
+    app_regs.waveform_start = 0;
+    app_regs.waveform_abort = 0;
+    app_regs.waveform_finished = 0;
+    app_regs.sample_rate_hz = DEFAULT_WAVEFORM_SAMPLE_RATE_HZ;
+
     multicore_reset_core1(); // Ensure core1 is not updating the player first.
     player.reset();
-    player.set_frequency_hz(500'000);
-    player.setup(); // FIXME: Locks up if the files don't exist.
+    player.set_frequency_hz(DEFAULT_WAVEFORM_SAMPLE_RATE_HZ);
+    player.setup(); // Non-fatal if channel_N.bin files are missing.
+    waveform_player.reset();
+    waveform_player.set_sample_rate_hz(DEFAULT_WAVEFORM_SAMPLE_RATE_HZ);
+    for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    {
+        waveform_player.set_waveform_type(i,
+            WaveformType(app_regs.waveform_type[i]));
+        waveform_player.set_sine_settings(i, app_regs.sine_settings[i]);
+        waveform_player.set_pulse_settings(i, app_regs.pulse_settings[i]);
+    }
     // Launch core1.
     (void)multicore_fifo_pop_blocking(); // Wait until core1 is ready.
     multicore_launch_core1(core1main);
@@ -388,23 +615,41 @@ void __not_in_flash_func(handle_external_trigger)()
     // Start the waveform per the 1s in the channel.
     // Filter out the busy channels first.
     uint32_t trigger_mask = ((gpio_get_all64() & DI_PORT_MASK) >> DI_PORT_BASE);
-    // Combine waveform settings external triggers to the final mask.
-    uint32_t start_mask = 0;
+    // Route each matched channel to either the waveform player (if its
+    // waveform-mode trigger mask matches) or the file player. Busy channels
+    // in either player are skipped.
+    uint32_t file_start_mask = 0;
+    uint32_t waveform_start_mask = 0;
     for (size_t i = 0; i < NUM_CHANNELS; ++i)
     {
-        if (player.channel_is_busy(i)) // Skip re-triggering busy channels.
+        if (any_player_busy(i))
             continue;
-        // Check if any currently HIGH pins would trigger this channel.
+        const uint8_t wv_trig =
+            waveform_player.get_external_trigger_mask(i);
+        if (wv_trig != 0 && (trigger_mask & wv_trig))
+        {
+            waveform_start_mask |= (1u << i);
+            continue;
+        }
         if (trigger_mask & app_regs.dac_settings[i].external_trigger_mask)
-            start_mask |= (1u << i);
+            file_start_mask |= (1u << i);
     }
-    if (start_mask != 0)
+    if (waveform_start_mask != 0)
+    {
+        waveform_player.start(waveform_start_mask);
+        // Dispatched as a dac_start event; a dedicated waveform_start event
+        // can be added later if the distinction matters to the host.
+        ext_trigger_event_t trigger_event;
+        trigger_event.channel_start_mask = waveform_start_mask;
+        trigger_event.timestamp = time_us_64();
+        queue_try_add(&ext_trigger_event_queue, &trigger_event);
+    }
+    if (file_start_mask != 0)
     {
         ext_trigger_event_t trigger_event;
-        player.start(start_mask); // Can be started from core1.
-        trigger_event.channel_start_mask = start_mask;
+        player.start(file_start_mask); // Can be started from core1.
+        trigger_event.channel_start_mask = file_start_mask;
         trigger_event.timestamp = time_us_64();
-        // Push harp message
         queue_try_add(&ext_trigger_event_queue, &trigger_event);
     }
     // Acknowledge the interrupt. Assume nothing else is setting these pins.

--- a/software/pyharp/app_registers.py
+++ b/software/pyharp/app_registers.py
@@ -1,4 +1,4 @@
-"""App registers for the cuttlefish."""
+"""App registers for the quad-DAC device."""
 from enum import IntEnum
 
 
@@ -35,4 +35,49 @@ class AppRegs(IntEnum):
     WaveformData1 = 55
     WaveformData2 = 56
     WaveformData3 = 57
+
+    # --- MultiWaveformPlayer registers (sine + pulse train generator). ---
+    WaveformType0 = 58
+    WaveformType1 = 59
+    WaveformType2 = 60
+    WaveformType3 = 61
+
+    # SineWaveSettings (11 bytes, U8 array):
+    #   <I frequency_hz>  <I duration_us>  <H amplitude>  <B external_trigger_mask>
+    # struct format: "<IIHB"
+    SineSettings0 = 62
+    SineSettings1 = 63
+    SineSettings2 = 64
+    SineSettings3 = 65
+
+    # PulseTrainSettings (23 bytes, U8 array):
+    #   <I pulse_width_us>
+    #   <I pulse_interval_us>
+    #   <H pulse_amplitude>
+    #   <I ramp_on_duration_us>
+    #   <I ramp_off_duration_us>
+    #   <I total_duration_us>
+    #   <B external_trigger_mask>
+    # struct format: "<IIHIIIB"
+    PulseSettings0 = 66
+    PulseSettings1 = 67
+    PulseSettings2 = 68
+    PulseSettings3 = 69
+
+    WaveformStart = 70      # U8 bitmask (write-only)
+    WaveformAbort = 71      # U8 bitmask (write-only)
+    WaveformFinished = 72   # U8 bitmask (event-only)
+
+    SampleRateHz = 73       # U32; shared DMA pacing rate, default 10_000
+
+
+# Values for the WaveformTypeN registers.
+class WaveformType(IntEnum):
+    Sine = 0
+    PulseTrain = 1
+
+
+# struct format strings matching the packed C++ structs in firmware/inc.
+SINE_SETTINGS_FMT = "<IIHB"       # 11 bytes
+PULSE_SETTINGS_FMT = "<IIHIIIB"   # 23 bytes
 

--- a/software/pyharp/sw_trigger_pulse_train.py
+++ b/software/pyharp/sw_trigger_pulse_train.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Configure and software-trigger a trapezoidal pulse train on AO channel 0.
+
+Harp message sequence:
+  1. (optional) write SampleRateHz to change the shared DMA pacing rate.
+  2. write WaveformType0 = PulseTrain.
+  3. write PulseSettings0 (packed struct, 23 bytes) with the parameters.
+  4. write WaveformStart = 0b0001 to fire channel 0.
+  5. wait for the WaveformFinished event.
+"""
+import logging
+import os
+from time import sleep
+
+from pyharp.device import Device
+from pyharp.messages import (
+    WriteU8HarpMessage,
+    WriteU8ArrayMessage,
+    WriteU32HarpMessage,
+)
+
+from app_registers import AppRegs, WaveformType, PULSE_SETTINGS_FMT
+
+# logging.basicConfig(level=logging.DEBUG)
+
+CHANNEL = 0
+
+
+def main():
+    if os.name == "posix":  # Linux / macOS
+        device = Device("/dev/ttyACM0", "ibl.bin")
+    else:  # Windows
+        device = Device("COM13", "ibl.bin")
+
+    # ----- 1) Sample rate. -----
+    # 10 kHz is the firmware default; writing explicitly makes the script
+    # self-contained.
+    sample_rate_hz = 10_000
+    reply = device.send(
+        WriteU32HarpMessage(AppRegs.SampleRateHz, sample_rate_hz).frame
+    )
+    print(f"SampleRateHz -> {sample_rate_hz} ({reply.message_type.name})")
+
+    # ----- 2) Select PulseTrain on channel 0. -----
+    reply = device.send(
+        WriteU8HarpMessage(
+            AppRegs.WaveformType0 + CHANNEL, int(WaveformType.PulseTrain)
+        ).frame
+    )
+    print(
+        f"WaveformType[{CHANNEL}] -> PulseTrain "
+        f"({reply.message_type.name})"
+    )
+
+    # ----- 3) Configure the pulse train. -----
+    #   1 ms trapezoidal pulse every 10 ms, peak at +16384 DAC codes above
+    #   midscale (~+5 V on the bipolar +/-10 V board), 100 us rise,
+    #   300 us fall, run for 2 seconds total, no external trigger.
+    pulse_width_us       = 100_000      # flat-top duration
+    pulse_interval_us    = 200_000     # pulse-to-pulse period
+    pulse_amplitude      = 16_384     # DAC codes above midscale
+    ramp_on_duration_us  = 10_000
+    ramp_off_duration_us = 10_000
+    total_duration_us    = 1_100_000  # 0 = run forever
+    external_trigger_mask = 0         # no DI-based trigger
+
+    pulse_settings = (
+        pulse_width_us,
+        pulse_interval_us,
+        pulse_amplitude,
+        ramp_on_duration_us,
+        ramp_off_duration_us,
+        total_duration_us,
+        external_trigger_mask,
+    )
+    reply = device.send(
+        WriteU8ArrayMessage(
+            AppRegs.PulseSettings0 + CHANNEL,
+            PULSE_SETTINGS_FMT,
+            pulse_settings,
+        ).frame
+    )
+    print(f"PulseSettings[{CHANNEL}] -> {pulse_settings} "
+          f"({reply.message_type.name})")
+
+    # Small delay so core1 has definitely finished the previous reset_app
+    # cycle before we trigger.
+    sleep(0.05)
+
+    # ----- 4) Trigger the waveform. -----
+    start_mask = 1 << CHANNEL
+    reply = device.send(
+        WriteU8HarpMessage(AppRegs.WaveformStart, start_mask).frame
+    )
+    print(
+        f"WaveformStart = 0x{start_mask:02x} "
+        f"({reply.message_type.name}, t={reply.timestamp})"
+    )
+
+    # ----- 5) Wait for the WaveformFinished event. -----
+    print("Waiting for WaveformFinished event...")
+    remaining_channels = start_mask
+    while remaining_channels:
+        for msg in device.get_events():
+            if msg.address == AppRegs.WaveformFinished:
+                finished = msg.payload[0]
+                print(
+                    f"WaveformFinished: 0x{finished:02x} at t={msg.timestamp}"
+                )
+                remaining_channels &= ~finished
+        sleep(0.01)
+
+    print("Done.")
+    device.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/software/pyharp/sw_trigger_sine_wave.py
+++ b/software/pyharp/sw_trigger_sine_wave.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Configure and software-trigger a raised-cosine sine wave on AO channel 0.
+
+Harp message sequence:
+  1. (optional) write SampleRateHz to change the shared DMA pacing rate.
+  2. write WaveformType0 = Sine.
+  3. write SineSettings0 (packed struct, 11 bytes) with the parameters.
+  4. write WaveformStart = 0b0001 to fire channel 0.
+  5. wait for the WaveformFinished event.
+
+Output shape: sample = midscale + amplitude * (1 - cos(phase)) / 2
+  * starts and ends at 0 V (DAC midscale on the bipolar +/-10 V board).
+  * peaks at `midscale + amplitude`.
+"""
+import logging
+import os
+from time import sleep
+
+from pyharp.device import Device
+from pyharp.messages import (
+    WriteU8HarpMessage,
+    WriteU8ArrayMessage,
+    WriteU32HarpMessage,
+)
+
+from app_registers import AppRegs, WaveformType, SINE_SETTINGS_FMT
+
+# logging.basicConfig(level=logging.DEBUG)
+
+CHANNEL = 0
+
+
+def main():
+    if os.name == "posix":  # Linux / macOS
+        device = Device("/dev/ttyACM0", "ibl.bin")
+    else:  # Windows
+        device = Device("COM13", "ibl.bin")
+
+    # ----- 1) Sample rate. -----
+    # 10 kHz is the firmware default; writing explicitly makes the script
+    # self-contained. Higher rates let you generate higher-frequency sines
+    # (Nyquist = sample_rate / 2), but require more DMA/core1 headroom.
+    sample_rate_hz = 10_000
+    reply = device.send(
+        WriteU32HarpMessage(AppRegs.SampleRateHz, sample_rate_hz).frame
+    )
+    print(f"SampleRateHz -> {sample_rate_hz} ({reply.message_type.name})")
+
+    # ----- 2) Select Sine on channel 0. -----
+    reply = device.send(
+        WriteU8HarpMessage(
+            AppRegs.WaveformType0 + CHANNEL, int(WaveformType.Sine)
+        ).frame
+    )
+    print(
+        f"WaveformType[{CHANNEL}] -> Sine "
+        f"({reply.message_type.name})"
+    )
+
+    # ----- 3) Configure the sine wave. -----
+    #   100 Hz raised-cosine sine for 2 s, peaking at +16384 DAC codes above
+    #   midscale (~+5 V on the bipolar +/-10 V board), no external trigger.
+    frequency_hz          = 10
+    duration_us           = 2_000_000  # 0 = run forever
+    amplitude             = 16_384     # DAC codes above midscale
+    external_trigger_mask = 0          # no DI-based trigger
+
+    sine_settings = (
+        frequency_hz,
+        duration_us,
+        amplitude,
+        external_trigger_mask,
+    )
+    reply = device.send(
+        WriteU8ArrayMessage(
+            AppRegs.SineSettings0 + CHANNEL,
+            SINE_SETTINGS_FMT,
+            sine_settings,
+        ).frame
+    )
+    print(f"SineSettings[{CHANNEL}] -> {sine_settings} "
+          f"({reply.message_type.name})")
+
+    # Small delay so core1 has definitely finished the previous reset_app
+    # cycle before we trigger.
+    sleep(0.05)
+
+    # ----- 4) Trigger the waveform. -----
+    start_mask = 1 << CHANNEL
+    reply = device.send(
+        WriteU8HarpMessage(AppRegs.WaveformStart, start_mask).frame
+    )
+    print(
+        f"WaveformStart = 0x{start_mask:02x} "
+        f"({reply.message_type.name}, t={reply.timestamp})"
+    )
+
+    # ----- 5) Wait for the WaveformFinished event. -----
+    print("Waiting for WaveformFinished event...")
+    remaining_channels = start_mask
+    while remaining_channels:
+        for msg in device.get_events():
+            if msg.address == AppRegs.WaveformFinished:
+                finished = msg.payload[0]
+                print(
+                    f"WaveformFinished: 0x{finished:02x} at t={msg.timestamp}"
+                )
+                remaining_channels &= ~finished
+        sleep(0.01)
+
+    print("Done.")
+    device.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
•  Adds `MultiWaveformPlayer`, a new header-only class that synthesizes raised cosine waves and trapezoidal pulse trains with asymmetric ramp-on / ramp-off durations. It coexists with` MultiFilePlayer` by borrowing its DMA double-buffers, staying within the RP2350 DMA channel budget.

•  Extends`MultiFilePlayer` with `abandon_files` / `reclaim_files` / `get_file_buf` accessors and makes `setup()` tolerant of a missing SD card, so the device can run waveform generation with no card inserted.

•  New Harp registers at addresses 58–73:` WaveformType[0..3]`, `SineSettings[0..3]`, `PulseSettings[0..3]`, `WaveformStart`, `WaveformAbort`, `WaveformFinished`, and `SampleRateHz`. Existing register layout is unchanged; the default DMA pacing rate after reset is now 10 kHz.

•  Event dispatch in `update_app()` now splits each end-of-transfer mask between `DACFinished` (file player) and `WaveformFinished` (waveform player) based on which source owned the channel.

•  `software/pyharp`: adds the new register enum values plus `sw_trigger_sine_wave.py` and `sw_trigger_pulse_train.py` reference scripts.