### PR TITLE
N-times and Exact Output Bugfixes

### DIFF
--- a/firmware/inc/dma_double_buffer.h
+++ b/firmware/inc/dma_double_buffer.h
@@ -32,7 +32,9 @@ protected:
  */
     DMADoubleBuffer()
     :ctrl_chan_{-1}, data_chan_{-1}, end_of_transfer_irq_num_{-1},
-    trigger_isr_{false}{}
+    trigger_isr_{false}, target_address_{nullptr},
+    ctrl_chan_data_{&buffers_[0], &buffers_[1]},
+    last_xfer_idle_buffer_ptr_{(T*)ctrl_chan_data_[0]}{}
 
 public:
 /**
@@ -55,6 +57,7 @@ public:
 
     void setup_transfer(dreq_num_t pacing_signal, volatile void* target_address)
     {
+        target_address_ = target_address; // Save for setting up last transfer.
         ctrl_chan_ = dma_claim_unused_channel(true);
         data_chan_ = dma_claim_unused_channel(true);
         // Setup the control channel.
@@ -62,8 +65,6 @@ public:
         // is invoked using the ring feature.
         // Write to update the data channel's read address.
         // Use alias3 to start the transfer in one write.
-        ctrl_chan_data_[0] = &buffers_[0];
-        ctrl_chan_data_[1] = &buffers_[1];
         dma_channel_config ctrl_chan_cfg = dma_channel_get_default_config(ctrl_chan_);
         channel_config_set_dreq(&ctrl_chan_cfg, DREQ_FORCE); // Go as fast as possible.
         channel_config_set_transfer_data_size(&ctrl_chan_cfg, DMA_SIZE_32); // system address size.
@@ -124,9 +125,26 @@ public:
     inline void load_buffer(T* word_source, size_t num_words)
     {memcpy(get_idle_buffer(), word_source, num_words*sizeof(T));}
 
-    //T (*get_idle_buffer())[BUF_SIZE]
-    T* get_idle_buffer()
-    {return *((T**)(dma_channel_hw_addr(ctrl_chan_)->read_addr));}
+/**
+* \brief get pointer to the current idle buffer.
+*/
+    inline T* get_idle_buffer()
+    {
+        // Edge case: we are executing the last transfer.
+        //   idle buffer is what we saved.
+        if (dma_chain_loop_disconnected())
+            return last_xfer_idle_buffer_ptr_;
+        // Normal case. idle buffer can be read from ctrl chan which points to
+        //   the *next* buffer to read from and wraps automatically.
+        return *((T**)(dma_channel_hw_addr(ctrl_chan_)->read_addr));
+    }
+
+    inline T* get_active_buffer()
+    {
+        return (get_idle_buffer() == (T*)ctrl_chan_data_[0])?
+            (T*)ctrl_chan_data_[1]:
+            (T*)ctrl_chan_data_[0];
+    }
 
 /**
  * \brief Enable the last completed dma transfer to trigger an interrupt
@@ -160,20 +178,40 @@ public:
  */
     void setup_last_dma_transfer(size_t word_count)
     {
-        // setting the transfer count while the dma channel is running sets the
-        // *next* transfer count; it doesn't affect the active transfer.
-        // ref: RP2350 pg 1126
-        //TODO: uint32_t encoded_transfer_count = dma_encode_transfer_count(word_count);
-        dma_channel_hw_addr(data_chan_)->transfer_count = word_count;
+        // Record idle buffer when last transfer is running.
+        last_xfer_idle_buffer_ptr_ = get_active_buffer();
         // Attach channel to IRQ if configured to do so:
         dma_irqn_set_channel_enabled(end_of_transfer_irq_num_, data_chan_,
                                      trigger_isr_);
         // Disable chaining on the next transfer.
         // Modifying the CTRL register updates settings for the *next* transfer.
-        dma_channel_config cfg = dma_get_channel_config(data_chan_);
-        channel_config_set_chain_to(&cfg, data_chan_); // chain-to-self disables chaining.
-        channel_config_set_irq_quiet(&cfg, false); // Enable end of transfer irq
-        dma_channel_set_config(data_chan_, &cfg, false); // trigger = false
+        //// Setup control block to write to data_chan_ to reconfigure and trigger
+        //// it on the final transfer.
+        dma_channel_config last_cfg = data_chan_default_cfg_;
+        channel_config_set_chain_to(&last_cfg, data_chan_); // chain-to-self disables chaining.
+        channel_config_set_irq_quiet(&last_cfg, false); // Enable end of transfer irq
+        ctrl_chan_last_xfer_data_ =
+            ctrl_chan_data_al0_t(reinterpret_cast<T(*)[BUF_SIZE]>(get_idle_buffer()),
+                                 target_address_, word_count, last_cfg);
+        // Setup ctrl_chan with final transfer config.
+        // When the ctrl channel is next triggered by the data channel,
+        // write 4 words to reconfigure and trigger the data channel (alias0).
+        // to send the final transfer.
+        dma_channel_config ctrl_chan_cfg = dma_channel_get_default_config(ctrl_chan_);
+        channel_config_set_dreq(&ctrl_chan_cfg, DREQ_FORCE); // Go as fast as possible.
+        channel_config_set_transfer_data_size(&ctrl_chan_cfg, DMA_SIZE_32);
+        channel_config_set_read_increment(&ctrl_chan_cfg, true);
+        channel_config_set_write_increment(&ctrl_chan_cfg, true);
+        channel_config_set_irq_quiet(&ctrl_chan_cfg, true);
+        channel_config_set_chain_to(&ctrl_chan_cfg, ctrl_chan_); // disable chaining.
+        const size_t ctrl_chan_data_word_count = sizeof(ctrl_chan_data_al0_t)/sizeof(uint32_t);
+        static_assert(ctrl_chan_data_word_count == 4);
+        // Apply the configuration.
+        dma_channel_configure(ctrl_chan_, &ctrl_chan_cfg,
+                              &dma_hw->ch[data_chan_].read_addr, // 4 writes will end on ctrl_trig
+                              &ctrl_chan_last_xfer_data_,      // read address.
+                              ctrl_chan_data_word_count,
+                              false);  // Don't start.
     }
 
 /**
@@ -302,13 +340,24 @@ public:
  *  ready to kick off a transfer sequence) set by the most recent call to
  * setup_transfer().
  */
-    void reset_transfer_config()
+    void reset_transfer_config(bool reset_idle_buffer = true)
     {
-        // For ctrl_chan_ we must additionally reset the idle buffer because
-        // ping-ponging between buffers is specified relative to the starting
-        // buffer address.
-        dma_channel_set_read_addr(ctrl_chan_, &ctrl_chan_data_[0], false);
-        dma_channel_set_config(ctrl_chan_, &ctrl_chan_default_cfg_, false);
+        // Reset buffer tracking if specified.
+        // true -> full reset.
+        // false -> reset everything except buffer tracking such that restarting
+        //   can start from the buffer that may have been filled while clocking
+        //   out the last transfer from the prevous playthrough.
+        T** ctrl_chan_data_start_addr =
+            (last_xfer_idle_buffer_ptr_ == (T*)ctrl_chan_data_[0])?
+                (T**)&ctrl_chan_data_[0]:
+                (T**)&ctrl_chan_data_[1];
+        if (reset_idle_buffer)
+            ctrl_chan_data_start_addr = (T**)&ctrl_chan_data_[0];
+        dma_channel_configure(ctrl_chan_, &ctrl_chan_default_cfg_,
+                              &dma_hw->ch[data_chan_].al3_read_addr_trig, // write address
+                              ctrl_chan_data_start_addr,
+                              1,
+                              false);  // Don't start.
         // For data_chan_ we must additionally reset the transfer count since
         // it was likely altered for the last buffer transfer.
         dma_channel_hw_addr(data_chan_)->transfer_count = BUF_SIZE;
@@ -355,6 +404,24 @@ public:
 
 private:
 /**
+ * \brief data sent from ctrl_chan_ to data_chan_ to configure data_chan_'s
+ * last transfer.
+ * \details On every trigger of the ctrl_chan_ we need to reconfigure data_chan_
+ * with an updated CTRL and READ_ADDR and then trigger data_chan_.
+ * Since no alias exists where we can trigger both registers above in two writes
+ * that end with a trigger, we need to perform 4 writes.
+ */
+#pragma pack(push, 1)
+    struct ctrl_chan_data_al0_t
+    {
+        T (*read_address)[BUF_SIZE];
+        volatile void* write_address;
+        uint32_t transfer_count; // in words, not bytes.
+        dma_channel_config data_chan_cfg;
+    };
+#pragma pack(pop)
+
+/**
  * \brief get the chained channel encoded in the given dma channel config.
  */
     inline uint32_t get_chained_channel(dma_channel_config cfg)
@@ -363,13 +430,16 @@ private:
                 >> DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB);
     }
 
-
-    alignas(8*sizeof(T)) T buffers_[2][BUF_SIZE];
+    T buffers_[2][BUF_SIZE];
     int ctrl_chan_;
     dma_channel_config ctrl_chan_default_cfg_;
-    T (*ctrl_chan_data_[2])[BUF_SIZE];
+    /// align to 8 byte boundary for ctrl_chan_ ring buffer settings.
+    alignas(8) const T (*ctrl_chan_data_[2])[BUF_SIZE];
+    ctrl_chan_data_al0_t ctrl_chan_last_xfer_data_;
+    T* last_xfer_idle_buffer_ptr_;
     int data_chan_;
     dma_channel_config data_chan_default_cfg_;
+    volatile void* target_address_;
 
     int end_of_transfer_irq_num_;
     bool trigger_isr_;

--- a/firmware/inc/file_player.h
+++ b/firmware/inc/file_player.h
@@ -55,6 +55,8 @@ public:
         // the new settings.
         if (file_is_open())
             return open_file(settings_.path);
+        // FIXME: edge case where we specify reading a subset of the file that
+        //   is longer than the actual file. We need to check f_size.
         return true;
     }
 

--- a/firmware/inc/function_player.h
+++ b/firmware/inc/function_player.h
@@ -21,13 +21,12 @@ public:
 
 protected:
 /**
- * \brief true if the file has been fully read to the end.
+ * \brief true if the function has played through to the end under its current
+ * settings.
  */
     inline virtual bool source_finished()
     {
-        if (this->settings_ptr_->duration_us == 0) // never finished in this case.
-            return false;
-        return this->sample_count_ == this->samples_emitted_;
+        return false; // functions are technically endless.
     }
 
 /**

--- a/firmware/inc/source_player.h
+++ b/firmware/inc/source_player.h
@@ -279,6 +279,8 @@ public:
         // Pad out the rest of the chunk if we didn't read a full chunk.
         if (chunk_bytes_read_ == CHUNK_SIZE_BYTES)
             return;
+        // FIXME: naive approach does not handle case where source is shorter
+        // than buffer.
         transfer_source_chunk(idle_buf_ptr_ + chunk_samples_read,
                               CHUNK_SIZE_BYTES - chunk_bytes_read_,
                               chunk_bytes_read_);

--- a/firmware/inc/source_player.h
+++ b/firmware/inc/source_player.h
@@ -23,7 +23,8 @@ public:
     SourcePlayer()
     : idle_buf_ptr_{nullptr}, buf_ptr_{nullptr}, curr_cycles_{0},
     settings_ptr_{nullptr}, samples_emitted_{0}, total_samples_emitted_{0},
-    chunk_bytes_read_{0}, manage_buffer_timing_{false}, is_updating{false}
+    chunk_bytes_read_{0}, manage_buffer_timing_{false}, is_updating{false},
+    is_armed_{false}
     {}
 
 /**
@@ -115,8 +116,13 @@ public:
     virtual void reset()
     {
         abort_transfer(); // Will deassert is_busy()
+        // Don't reset tracking of underlying buffers.
+        if (buf_ptr_ != nullptr)
+            buf_ptr_->reset_transfer_config(false);
         while (is_updating.load()) // wait for core1 update to finish any update.
             __asm__ __volatile__ ("nop");
+        is_armed_ = false;
+        idle_buf_ptr_ = nullptr;
         total_samples_emitted_ = 0;
         curr_cycles_ = 0;
         samples_emitted_ = 0;
@@ -182,21 +188,8 @@ public:
         // -> Player has played at least once and needs to be reset() before
         //    we can rerun it.
 
-        // Bail-early case: buffer is fully stuffed.
-        if (total_samples_emitted_ >= BUF_SIZE)
-            return true;
-        // Play-forever or play-to-completion case.
-        if (sample_count_ == 0)
-        {
-            // Short finite source that's smaller than the buffer.
-            // i.e: play-to-completion.
-            if (curr_cycles_ == settings_ptr_->cycles) // i.e: source finished.
-                return true;
-        }
-        // Bounded sample count and finite source that is also short.
-        else if (sample_count_ < BUF_SIZE)
-            return total_samples_emitted_ == sample_count_;
-        return false; // shouldn't happen unless there are cases we haven't found.
+        // Once armed, always armed unless reset.
+        return is_armed_;
     }
 
 /**
@@ -243,54 +236,42 @@ public:
     inline void _update()
     {
         // TODO: deadlne check between chunk transfers to ensure buffers are topped off.
-        size_t chunk_samples_read;
-        size_t bytes_to_read;
         if (output_buffer_unspecified())
             return;
         // Skip if channel is ready but not transferring.
-        bool active = is_active();
-        bool armed = is_armed();
-        if (!active && armed)
-            return;
-        // Handle playback finished or aborted condition (i.e: needs rewind).
-        if (!active && !armed)
-        {
-            buf_ptr_->reset_transfer_config();
-            rewind_source();
-        } // Keep going.
-        // Skip if we setup last DMA transfer, but it hasn't finished yet.
-        if (active && buf_ptr_->dma_chain_loop_disconnected())
+        if (!is_active() && is_armed())
             return;
         // Skip if channel is active but buffer hasn't switched yet.
         if (idle_buf_ptr_ == buf_ptr_->get_idle_buffer())
             return;
         idle_buf_ptr_ = buf_ptr_->get_idle_buffer();
-        // Transfer data from card to double-buffer.
-        // Read up to a chunk or up to the subset specified.
-        bytes_to_read = (sample_count_ == 0) ?
+        // Transfer data from source to idle buffer.
+        // Read a full chunk or up to the subset specified.
+        size_t bytes_to_read = (sample_count_ == 0) ?
             CHUNK_SIZE_BYTES:
             std::min(size_t((sample_count_ - samples_emitted_) * sizeof(T)),
                      CHUNK_SIZE_BYTES);
         transfer_source_chunk(idle_buf_ptr_, bytes_to_read, chunk_bytes_read_);
-        chunk_samples_read = chunk_bytes_read_ / sizeof(T);
+        size_t chunk_samples_read = chunk_bytes_read_ / sizeof(T);
         samples_emitted_ += chunk_samples_read;
         total_samples_emitted_ += chunk_samples_read;
         bool source_subset_finished = ((samples_emitted_ == sample_count_)
                                        && (sample_count_ != 0));
+        is_armed_ = true;
         if (!source_finished() && !source_subset_finished)
             return;
         // Handle end-of-source (or end of subset of source).
          ++curr_cycles_; // increment full source read iterations.
+         samples_emitted_ = 0; // Reset tracking of samples within a cycle.
         // Handle last transfer condition.
         if ((curr_cycles_ == settings_ptr_->cycles) && (settings_ptr_->cycles != 0))
         {
             // Next transfer will be the last transfer.
-            //printf("EOF at %llu. Setting up last transfer\r\n", fil_.fptr);
-            // Current idle buffer is the last active buffer
-            buf_ptr_->setup_last_dma_transfer(chunk_bytes_read_ / sizeof(T));
-            idle_buf_ptr_ = nullptr; // Trigger a re-arm on next update.
-            curr_cycles_ = 0; // reset counter for next round.
-            samples_emitted_ = 0;
+            // The next update() tick will reload waveform from the beginning.
+            // At that point, user will be able to retrigger the waveform once
+            // is_busy() is false.
+            buf_ptr_->setup_last_dma_transfer(chunk_samples_read);
+            curr_cycles_ = 0;
             return;
         }
         // Handle endless/many-iteration transfer condition.
@@ -298,8 +279,8 @@ public:
         // Pad out the rest of the chunk if we didn't read a full chunk.
         if (chunk_bytes_read_ == CHUNK_SIZE_BYTES)
             return;
-        transfer_source_chunk(idle_buf_ptr_ + chunk_bytes_read_/sizeof(T),
-                              (CHUNK_SIZE_BYTES - chunk_bytes_read_),
+        transfer_source_chunk(idle_buf_ptr_ + chunk_samples_read,
+                              CHUNK_SIZE_BYTES - chunk_bytes_read_,
                               chunk_bytes_read_);
         chunk_samples_read = chunk_bytes_read_ / sizeof(T);
         samples_emitted_ += chunk_samples_read;
@@ -331,13 +312,15 @@ protected:
  */
     inline virtual bool source_finished() = 0;
 
-    uint32_t total_samples_emitted_;
+    bool is_armed_;
+    uint32_t total_samples_emitted_; // Never resets unless we call reset()
     size_t curr_cycles_; /// elapsed cycles of the specified settings
                          /// (NOT cycles of a periodic waveform).
     uint32_t samples_emitted_; /// samples emitted within a cycle. resets to 0.
                                /// upon reset() or at the beginning of each
                                /// cycle.
     uint32_t sample_count_; // Cached value. Recomputed on reset().
+                            // Number of samples within a cycle.
     size_t chunk_bytes_read_; /// bytes read after the most recent call to
                               /// transfer_source_chunk().
     DMADoubleBuffer<T, BUF_SIZE>* buf_ptr_;

--- a/firmware/inc/waveform_settings.h
+++ b/firmware/inc/waveform_settings.h
@@ -24,7 +24,11 @@ struct WaveformSettings
     : cycles{cycles}, duration_us{duration_us},
       update_frequency_hz{update_frequency_hz}{}
 
-/// \brief get number of samples associated with the \ref duration_us setting.
+/**
+ * \brief get number of samples within a cycle associated with the
+ *  \ref duration_us setting.
+ *  May be zero if WaveformSettings.duration_us is zero (loop-forever case).
+ **/
     uint32_t sample_count()
     {return uint32_t((float(duration_us) * update_frequency_hz / 1.0E6));}
 };
@@ -126,17 +130,5 @@ struct TrapezoidSettings: FunctionSettings
     // TODO: Sawtooth constructor
 };
 #pragma pack(pop)
-
-
-#pragma pack(push, 1)
-/**
- * \brief base waveform settings and additional settings for Harp interface.
- */
-struct WaveformInterfaceSettings: WaveformSettings
-{
-    uint8_t external_trigger_mask;
-};
-#pragma pack(pop)
-
 
 #endif // WAVEFORM_SETTINGS_H

--- a/software/pyharp/app_registers.py
+++ b/software/pyharp/app_registers.py
@@ -22,6 +22,7 @@ class WaveformType(IntEnum):
 
 
 # struct format strings matching the packed C++ structs in firmware/inc.
+FILE_SETTINGS_FMT = "<III33s"
 SINE_SETTINGS_FMT = "<IIIIff"  # 24 bytes
 TRAPEZOID_SETTINGS_FMT = "<IIIIffII"  # 36 bytes
 

--- a/software/pyharp/sw_trigger_sine_wave.py
+++ b/software/pyharp/sw_trigger_sine_wave.py
@@ -15,10 +15,11 @@ WAVEFORM_TYPE =  WaveformType.Sine
 WAVEFORM_FMT = SINE_SETTINGS_FMT
 BASE_SETTINGS_REG = AppRegs.SineSettings0
 
-cycles = 1
-duration_us = 1_000_000
+
+cycles = 2
 sample_rate_hz = 10_000
 frequency_hz = 1
+duration_us = 2_000_000
 amplitude_volts = 2.5 # center-to-peak, not peak-to-peak
 vertical_shift_volts = 0
 
@@ -46,7 +47,6 @@ reply = device.send(WriteU8ArrayMessage(BASE_SETTINGS_REG + CHANNEL,
 print(f"SineSettings[{CHANNEL}] -> {settings}, ({reply.message_type.name})")
 print(f"reply: {unpack(WAVEFORM_FMT, bytes(reply.payload))}")
 print()
-
 # Ensure waveform is ready.
 channel_is_ready = False
 while not channel_is_ready:
@@ -55,25 +55,36 @@ while not channel_is_ready:
     if not channel_is_ready:
         print(f"Channel[{CHANNEL}] is not yet ready...")
         sleep(0.1)
-print(f"Channel[{CHANNEL}] is ready.")
 
-# Trigger waveform.
-print("Starting waveform.")
-start_mask = 1 << CHANNEL
-reply = device.send(WriteU8HarpMessage(AppRegs.DACStart, start_mask).frame)
-print(f" Read back: 0x{reply.payload[0]:02x} ({reply.message_type.name}), "
-      f"time: {reply.timestamp}")
-
-# Wait for waveform-finished event.
-print("Waiting for end-of-waveform event.")
-waveform_playing = True
-while waveform_playing:
-    events = device.get_events()
-    for msg in events:
-        print(msg)
-        print()
-        if msg.address == AppRegs.DACFinished:
-            waveform_playing = False
-
-print("Done.")
+while (True):
+    try:
+        # Ensure waveform is ready.
+        channel_is_ready = False
+        while not channel_is_ready:
+            reply = device.send(ReadU8HarpMessage(AppRegs.DACReady).frame)
+            channel_is_ready = bool(reply.payload[0] >> CHANNEL)
+            if not channel_is_ready:
+                print(f"Channel[{CHANNEL}] is not yet ready...")
+                sleep(0.1)
+        print(f"Channel[{CHANNEL}] is ready.")
+        input("press Enter to start.")
+        print("Starting waveform.")
+        start_mask = 1 << CHANNEL
+        reply = device.send(WriteU8HarpMessage(AppRegs.DACStart, start_mask).frame)
+        print(f" Read back: 0x{reply.payload[0]:02x} ({reply.message_type.name}), "
+            f"time: {reply.timestamp}")
+        # Wait for waveform-finished event.
+        print("Waiting for end-of-waveform event.")
+        waveform_playing = True
+        while waveform_playing:
+            events = device.get_events()
+            for msg in events:
+                print(msg)
+                print()
+                if msg.address == AppRegs.DACFinished:
+                    waveform_playing = False
+        # Re-trigger waveform.
+    except KeyboardInterrupt:
+        break
+print("Disconnecting.")
 device.disconnect()

--- a/software/pyharp/sw_trigger_single_shot_waveform.py
+++ b/software/pyharp/sw_trigger_single_shot_waveform.py
@@ -13,7 +13,7 @@ COM_PORT = "/dev/ttyACM0"
 WAVEFORM_TYPE =  WaveformType.File
 WAVEFORM_FMT = FILE_SETTINGS_FMT
 BASE_SETTINGS_REG = AppRegs.FileSettings0
-NUM_CHANNELS = 1
+NUM_CHANNELS = 4
 
 # Open the device and print the info on screen
 # Open serial connection and save communication to a file

--- a/software/pyharp/sw_trigger_single_shot_waveform.py
+++ b/software/pyharp/sw_trigger_single_shot_waveform.py
@@ -1,22 +1,34 @@
 #!/usr/bin/env python3
 from pyharp.device import Device
-from pyharp.messages import ReadU8HarpMessage, WriteU8HarpMessage
-from struct import pack, unpack
+from pyharp.messages import ReadU8HarpMessage, WriteU8ArrayMessage, WriteU8HarpMessage
 import logging
-import os
+from struct import unpack
 from time import sleep
-from app_registers import AppRegs, WaveformType
+from app_registers import AppRegs, WaveformType, FILE_SETTINGS_FMT
 import sys
 
 #logging.basicConfig(level=logging.DEBUG)
 COM_PORT = "/dev/ttyACM0"
 
 WAVEFORM_TYPE =  WaveformType.File
-NUM_CHANNELS = 4
+WAVEFORM_FMT = FILE_SETTINGS_FMT
+BASE_SETTINGS_REG = AppRegs.FileSettings0
+NUM_CHANNELS = 1
 
 # Open the device and print the info on screen
 # Open serial connection and save communication to a file
 device = Device(COM_PORT, "ibl.bin")
+
+cycles = 5
+duration_us = 1_000_000
+sample_rate_hz = 500_000
+
+settings = [
+    (cycles, duration_us, sample_rate_hz, b"channel_0.bin"),
+    (cycles, duration_us, sample_rate_hz, b"channel_1.bin"),
+    (cycles, duration_us, sample_rate_hz, b"channel_2.bin"),
+    (cycles, duration_us, sample_rate_hz, b"channel_3.bin"),
+]
 
 print(f"Setting all active players to {WAVEFORM_TYPE.name}")
 for i in range(NUM_CHANNELS):
@@ -24,13 +36,25 @@ for i in range(NUM_CHANNELS):
                                            WAVEFORM_TYPE.value).frame)
     print(f" Read back: 0x{reply.payload[0]:02x} ({reply.message_type.name}), "
           f"time: {reply.timestamp}")
-sleep(0.1)
+print()
 
-print("Checking if players are ready.")
-reply = device.send(ReadU8HarpMessage(AppRegs.DACReady).frame)
-print(f" Read back: 0x{reply.payload[0]:02x}")
-if reply.payload[0] != 0b1111:
-    sys.exit("Error: players are not yet ready.")
+# Apply settings.
+for i in range(NUM_CHANNELS):
+    print(f"Applying FileSettings for waveform {i}.")
+    reply = device.send(WriteU8ArrayMessage(BASE_SETTINGS_REG + i,
+                                            WAVEFORM_FMT, settings[i]).frame)
+    print(f"Read back: ({reply.message_type.name}) "
+          f"{unpack(WAVEFORM_FMT, bytes(reply.payload))}")
+
+# Ensure waveform is ready.
+channels_ready = False
+while not channels_ready:
+    reply = device.send(ReadU8HarpMessage(AppRegs.DACReady).frame)
+    channels_ready = reply.payload[0] == 0b1111
+    if not channels_ready:
+        print(f"Not all channels are ready.... Current state: {reply.payload[0]:02x}")
+        sleep(0.1)
+print(f"Channels are all ready.")
 
 # Start each channel offset by 0.5 sec.
 for i in range(NUM_CHANNELS):


### PR DESCRIPTION
* simplify source player logic
* prevent multi-cycle waveform settings from playing forever *except* when waveform is less then buffer size
* make source player play exact number of samples instead of truncating to the nearest full buffer size.